### PR TITLE
Fix an error deleting device types with PIN codes

### DIFF
--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -272,7 +272,10 @@ def deviceTypeDelete(deviceType) {
         app.removeSetting("${deviceType.name}.type")
         app.removeSetting("${deviceType.name}.googleDeviceType")
         app.removeSetting("${deviceType.name}.devices")
-        deviceType.pinCodes.each { pinCode -> deleteDeviceTypePin(deviceType, pinCode.id) }
+        app.removeSetting("${deviceType.name}.confirmCommands")
+        app.removeSetting("${deviceType.name}.secureCommands")
+        def pinCodeIds = deviceType.pinCodes.collect { it.id }
+        pinCodeIds.each { pinCodeId -> deleteDeviceTypePin(deviceType, pinCodeId) }
         app.removeSetting("${deviceType.name}.pinCodes")
         deviceType.traits.each { traitType, deviceTrait -> deleteDeviceTrait(deviceTrait) }
         state.deviceTraits.remove(deviceType.name as String)


### PR DESCRIPTION
The device type delete logic was attempting to modify the list of
PIN codes while iterating over it.  This fixes the logic to first
gather the list of PIN codes and then iterate over that temp list.