### PR TITLE
Add importUrl

### DIFF
--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -23,7 +23,8 @@ definition(
     category: "Integrations",
     iconUrl: "",
     iconX2Url: "",
-    iconX3Url: ""
+    iconX3Url: "",
+    importUrl: "https://raw.githubusercontent.com/mbudnek/google-home-hubitat-community/master/google-home-community.groovy"
 )
 
 preferences {


### PR DESCRIPTION
The `importUrl` setting doesn't seem to work for apps, but it does serve as documentation.