### PR TITLE
Clamp openPercent parameter for non-discrete OpenClose

### DIFF
--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -1009,6 +1009,8 @@ private executeCommand_OpenClose(deviceInfo, command) {
         checkValue = { it in openCloseTrait.closedValue.split(",") }
     } else {
         checkMfa(deviceInfo.deviceType, "Set Position", command)
+        // Google uses 0...100 for position but hubitat uses 0...99, so clamp
+        openPercent = Math.min(openPercent, 99)
         deviceInfo.device."${openCloseTrait.openPositionCommand}"(openPercent)
         checkValue = openPercent
     }


### PR DESCRIPTION
Google will send an `openPercent` parameter in the range [0, 100], but Hubitat uses the range [0, 99], so clamp it so that we pass 99 to the driver when we get 100.