### PR TITLE
Add support for volume on devices w/o setVolume

### DIFF
--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -39,8 +39,9 @@
 //   * Apr 10 2020 - Add new device types: Carbon Monoxide Sensor, Charger, Remote Control, Set-Top Box,
 //                   Smoke Detector, Television, Water Purifier, and Water Softener
 //   * Apr 10 2020 - Add support for the Volume trait
-//   * Aug 05 2020 - Add suppoer for Camera trait
-//   * Aug 25 2020 - Add suppoer for Global PIN Codes
+//   * Aug 05 2020 - Add support for Camera trait
+//   * Aug 25 2020 - Add support for Global PIN Codes
+//   * Oct 03 2020 - Add support for devices not allowing volumeSet command when changing volume
 
 import groovy.json.JsonException
 import groovy.json.JsonOutput

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -1812,7 +1812,7 @@ private executeCommand_volumeRelative(deviceInfo, command) {
         }
 
         device."${volumeChangeCommand}"()
-        for (int i = 1; i < volumeTrait.volumeStep; i++) {
+        for (int i = 1; i < Math.abs(volumeChange); i++) {
             pauseExecution(100)
             device."${volumeChangeCommand}"()
         }

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -1216,12 +1216,36 @@ private deviceTraitPreferences_Volume(deviceTrait) {
             defaultValue: "volume"
         )
         input(
-            name: "${deviceTrait.name}.setVolumeCommand",
-            title: "Set Rotation Command",
-            type: "text",
-            required: true,
-            defaultValue: "setVolume"
+            name: "${deviceTrait.name}.canSetVolume",
+            title: "Use `setVolume` command (otherwise will use Volume Up/Down instead)",
+            type: "bool",
+            defaultValue: true,
+            submitOnChange: true
         )
+        if (deviceTrait.canSetVolume) {
+            input(
+                name: "${deviceTrait.name}.setVolumeCommand",
+                title: "Set Rotation Command",
+                type: "text",
+                required: true,
+                defaultValue: "setVolume"
+            )
+        } else {
+            input(
+                name: "${deviceTrait.name}.volumeUpCommand",
+                title: "Set Increase Volume Command",
+                type: "text",
+                required: true,
+                defaultValue: "volumeUp"
+            )
+            input(
+                name: "${deviceTrait.name}.volumeDownCommand",
+                title: "Set Decrease Volume Command",
+                type: "text",
+                required: true,
+                defaultValue: "volumeDown"
+            )
+        }
         input(
             name: "${deviceTrait.name}.volumeStep",
             title: "Volume Level Step",
@@ -1774,10 +1798,27 @@ private executeCommand_volumeRelative(deviceInfo, command) {
     def volumeChange = command.params.relativeSteps
     def device = deviceInfo.device
 
-    def currentVolume = device.currentValue(volumeTrait.volumeAttribute)
-    // volumeChange will be negative when decreasing volume
-    def newVolume = currentVolume + volumeChange
-    device."${volumeTrait.setVolumeCommand}"(newVolume)
+    def newVolume
+
+    if (volumeTrait.canSetVolume) {
+        def currentVolume = device.currentValue(volumeTrait.volumeAttribute)
+        // volumeChange will be negative when decreasing volume
+        newVolume = currentVolume + volumeChange
+        device."${volumeTrait.setVolumeCommand}"(newVolume)
+    } else {
+        def volumeChangeCommand = volumeTrait.volumeUpCommand
+        if (volumeChange < 0) {
+            volumeChangeCommand = volumeTrait.volumeDownCommand
+        }
+
+        device."${volumeChangeCommand}"()
+        for (int i = 1; i < volumeTrait.volumeStep; i++) {
+            pauseExecution(100)
+            device."${volumeChangeCommand}"()
+        }
+
+        newVolume = device.currentValue(volumeTrait.volumeAttribute)
+    }
 
     return [
         (volumeTrait.volumeAttribute): newVolume
@@ -2259,6 +2300,7 @@ private attributesForTrait_Volume(deviceTrait) {
     return [
         volumeMaxLevel:         100,
         volumeCanMuteAndUnmute: deviceTrait.canMuteUnmute,
+        volumeCanSetVolume:     deviceTrait.canSetVolume,
         levelStepSize:          deviceTrait.volumeStep
     ]
 }
@@ -2602,11 +2644,20 @@ private traitFromSettings_Volume(traitName) {
     if (canMuteUnmute == null) {
         canMuteUnmute = true
     }
+
+    def canSetVolume = settings."${traitName}.canSetVolume"
+    if (canSetVolume == null) {
+        canSetVolume = true
+    }
+
     def volumeTrait = [
-        volumeAttribute:  settings."${traitName}.volumeAttribute",
-        setVolumeCommand: settings."${traitName}.setVolumeCommand",
-        volumeStep:       settings."${traitName}.volumeStep",
-        canMuteUnmute:    canMuteUnmute,
+        volumeAttribute:   settings."${traitName}.volumeAttribute",
+        setVolumeCommand:  settings."${traitName}.setVolumeCommand",
+        volumeUpCommand:   settings."${traitName}.volumeUpCommand",
+        volumeDownCommand: settings."${traitName}.volumeDownCommand",
+        volumeStep:        settings."${traitName}.volumeStep",
+        canMuteUnmute:     canMuteUnmute,
+        canSetVolume:      canSetVolume,
         commands: ["Set Volume"],
     ]
 
@@ -2800,6 +2851,7 @@ private deleteDeviceTrait_Volume(deviceTrait) {
     app.removeSetting("${deviceTrait.name}.setVolumeCommand")
     app.removeSetting("${deviceTrait.name}.volumeStep")
     app.removeSetting("${deviceTrait.name}.canMuteUnmute")
+    app.removeSetting("${deviceTrait.name}.canSetVolume")
     app.removeSetting("${deviceTrait.name}.muteAttribute")
     app.removeSetting("${deviceTrait.name}.mutedValue")
     app.removeSetting("${deviceTrait.name}.unmutedValue")

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2300,7 +2300,6 @@ private attributesForTrait_Volume(deviceTrait) {
     return [
         volumeMaxLevel:         100,
         volumeCanMuteAndUnmute: deviceTrait.canMuteUnmute,
-        volumeCanSetVolume:     deviceTrait.canSetVolume,
         levelStepSize:          deviceTrait.volumeStep
     ]
 }

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.25",
+  "version": "0.26",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
### Major changes:
This adds support for configuring a device which has no `setVolume` with a set value, allowing to control such devices by using `volumeUp`/`volumeDown` commands.

### Use case:
- On LG WebOS TVs, when using an external sound system with HDMI ARC or Optical connection, the TV ignores any absolute volume specifications, and will only responds to relative changes.

### Breaking Changes:
n/a

### Notes:
- The Volume trait settings page was modified to allow specifying either `setVolume` OR `volumeUp` and `volumeDown`.
- All defaults remain as they were. When the new toggle is off, there's effectively no change.
- I also dislike the `pauseexecution` solution, but after significant testing, I don't really see any other way. That said, I'm no Groovy pro, and any comments or suggestions are most welcome.
- Example of the change in the settings page:
<img width="638" alt="image" src="https://user-images.githubusercontent.com/7327741/94724595-332a7c00-0363-11eb-834d-f59864aca061.png">

Thank you for maintaining this!