### PR TITLE
Fix a bug in the TemperatureControl trait

### DIFF
--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2000,11 +2000,11 @@ private deviceStateForTrait_TemperatureControl(deviceTrait, device) {
     if (deviceTrait.queryOnly) {
         state.temperatureSetpointCelsius = currentTemperature
     } else {
-        def setpoint = device.currentValue(deviceTrait.setpointAttribute)
+        def setpoint = device.currentValue(deviceTrait.currentSetpointAttribute)
         if (deviceTrait.temperatureUnit == "F") {
             setpoint = fahrenheitToCelsiusRounded(setpoint)
         }
-        state.temperatureSetpiontCelsius = setpoint
+        state.temperatureSetpointCelsius = setpoint
     }
 
     return state

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.26",
+  "version": "0.26.1",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
The TemperatureControl trait was using the wrong name for the current setpoint attribute.  It also had "setpoint" misspelled in another spot.