### PR TITLE
Fix the SetTemperature command of the TemperatureControl trait

### DIFF
--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -42,6 +42,7 @@
 //   * Aug 05 2020 - Add support for Camera trait
 //   * Aug 25 2020 - Add support for Global PIN Codes
 //   * Oct 03 2020 - Add support for devices not allowing volumeSet command when changing volume
+//   * Jan 18 2021 - Fix SetTemperature command of the TemperatureControl trait
 
 import groovy.json.JsonException
 import groovy.json.JsonOutput
@@ -1690,7 +1691,7 @@ private executeCommand_SetHumidity(deviceInfo, command) {
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_SetTemperature(deviceInfo, command) {
-    checkMfa(deviceInfo.deviceTrait, "Set Temperature", command)
+    checkMfa(deviceInfo.deviceType, "Set Temperature", command)
     def temperatureControlTrait = deviceInfo.deviceType.traits.TemperatureControl
     def setpoint = command.params.temperature
     if (temperatureControlTrait.temperatureUnit == "F") {

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
The SetTemperature handler was passing the wrong thing to the MFA check, which was causing it to fail on a NullPointerException