### PR TITLE
Avoid breaking the whole app because of a bad toggle

### DIFF
--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2834,6 +2834,9 @@ private traitFromSettings_Toggles(traitName) {
             traitName: traitName,
             labels: settings."${toggle}.labels"?.split(",")
         ]
+        if (toggleAttrs.labels == null) {
+            toggleAttrs.labels = ["Unknown"]
+        }
         toggleAttrs << traitFromSettings_OnOff(toggle)
         toggleAttrs
     }

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -44,6 +44,7 @@
 //   * Oct 03 2020 - Add support for devices not allowing volumeSet command when changing volume
 //   * Jan 18 2021 - Fix SetTemperature command of the TemperatureControl trait
 //   * Jan 19 2021 - Added Dock and StartStop Traits
+//   * Jan 31 2021 - Don't break the whole app if someone creates an invalid toggle
 
 import groovy.json.JsonException
 import groovy.json.JsonOutput

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.26.3",
+  "version": "0.26.4",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
When creating a new toggle in the Toggles trait it's possible to
leave the page without filling in any labels by either closing the
browser or clicking a link out of the app.  This would break the
entire app settings due to an error trying to load that bad toggle.

This adds a default "Unknown" label that will be used in that case
so that the app will continue to function and the user can delete
the bad toggle.