### PR TITLE
Added Energy Storage, Software Update, Reboot, Media State (query unt…

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,25 @@ The Dock trait is intended to be used for devices such as robot vacuum cleaners 
 - Docked Value: The value of the "Docked Attribute" that indicates that the device is currently docked.  Defaults to `docked`.
 - Dock Command: A device command used to tell the device to return to its dock.  Maps to `returnToDock` by default.
 
+### Energy Storage
+
+The Energy Storage trait is used for any device that can report energy capacity and optionally start charging.  It can be controlled by saying things like "Hey Google, charge {device}" and queried by saying things like "Hey Google, is {device} charging?", "Hey Google, What is {device} battery level?",
+"Hey Google, What is {device} battery percentage?", or "Hey Google, How long until {device} is fully charged?"  This trait has the following configuration parameters:
+
+- Rechargeable: Set to indicate that this device is rechargeable.  Defaults to 'false'.
+- Query Only Energy Storage: Set to indicate that this device can only be queried for energy storage and not controlled.
+- Supported Distance Units: Set to indicate that units the UI will use if the configured units are set to distance.
+- Descriptive Capacity Remaining Attribute: The device attribute used to query the current capacity of the device with descriptive text should no number capacity remaining value be reported.  Maps to the `descriptiveCapacityRemaining` attribute by default.
+- Capacity Remaining Value Attribute: The device attribute used to query the current capacity of the device.  Maps to the `capacityRemainingRawValue` attribute by default.
+- Capacity Remaining Unit Attribute: The device attribute used to indicate the units for Capacity Remaining Value Attribute.  Typical useful unit will be 'PERCENT'. 
+- Capacity Until Full Value Attribute: The device attribute used to query the capacity until full of the device.  Maps to the `capacityUntilFullRawValue` attribute by default.
+- Capacity Remaining Unit Attribute: The device attribute used to indicate the units for Capacity Until Full Value Value Attribute.  Typical useful unit will be 'SECONDS'.  
+- Charging Attribute: The device attribute used to query the current charging state of the device.  Maps to the `isCharging` attribute by default.
+- Charging Value: The value that the Charging attribute will report when the device is charging.  Defaults to 'true'.
+- Plugged In Attribute: The device attribute used to query the current plugged in state of the device.  Maps to the `isPluggedIn` attribute by default.
+- Plugged In Value: The value that the Plugged In attribute will report when the device is plugged in.  Defaults to 'true'.
+- Charge Command: A device command used to charge the device.  Maps to `charge` by default.
+
 ### Fan Speed
 
 The Fan Speed trait is primarily used for fan controllers with multiple speed settings.  It can be controlled by saying things like "Hey Google, set {device} to {speed}" and queried by saying things like "Hey Google, what's the {device} speed?".  It has the following configuration parameters:
@@ -195,7 +214,6 @@ The Locator trait is used for finding devices that have audible or visual indica
 
 - Locator Command: A device command used to locate the device.  Should not require any parameters.  Maps to `locate` by default.
 
-
 ### Lock/Unlock
 
 The Lock/Unlock trait is used for anything that can lock and unlock, such as doors and windows.  It can be controlled by saying things like "Hey Google, lock {device}" and queried by saying things like "Hey Google, is {device} locked?".  Since locks are often security-sensitive, it is recommended, though not required, that PIN code support be configured for device types implementing this trait.  The Lock/Unlock trait has the following configuration parameters:
@@ -204,6 +222,15 @@ The Lock/Unlock trait is used for anything that can lock and unlock, such as doo
 - Locked Value: The value that the Locked/Unlocked attribute will report when the device is locked.  Defaults to "locked".
 - Lock Command: A device command used to lock the device.  Should not require any parameters.  Maps to `lock` by default.
 - Lock Command: A device command used to unlock the device.  Should not require any parameters.  Maps to `unlock` by default.
+
+### Media State
+
+The Media State trait is used for reporting the current playback and activity state of a media device.  Query command is unknown at the is time.  The trait has the following configuration parameters:
+
+- Support Activity State: Should be set if this device can report the current activity state.  Defaults to 'false'.
+- Support Playback State: Should be set if this device can report the current playback state.  Defaults to 'false'.
+- Activity State Attribute: The device attribute used to query the current activity state of the device.  Maps to the `activityState` attribute by default.
+- Playback State Attribute: The device attribute used to query the current playback state of the device.  Maps to the `playbackState` attribute by default.
 
 ### On/Off
 
@@ -237,6 +264,12 @@ The Open/Close trait is used for devices that can be opened and closed such as d
         - Open Command: Only available if Query Only Open/Close is unset.  A device command used to open the device.  Should not require any parameters.  Maps to `open` by default.
         - Close Command: Only available if Query Only Open/Close is unset.  A device command used to close the device.  Should not require any parameters.  Maps to `close` by default.
 
+### Reboot
+
+The Reboot trait is used for devices that can be rebooted.  It can be controlled by saying things like "Hey Google, reboot {device}".  It has the following configuration parameters:
+
+- Reboot Command: A device command to reboot the device.  Maps to `reboot` by default.
+
 ### Rotation
 
 The Rotation trait is used for devices that can be rotated to a specific position such as slat blinds or a pivoting fan.  It can be controlled by saying things like "Hey Google, rotate {device} to 30%" and queried by saying things like "Hey Google, how far is {device} rotated?".  It has the following configuration parameters:
@@ -253,9 +286,16 @@ This is used for controlling scenes, and should generally only be used with the 
 - Can this scene be deactivated?: Should be left unset if this scene can only be activated and set if this scene can be both activated and deactivated.
 - Deactivate Command: A device command used to deactivate this scene.  Only available if the scene can be deactivated.  Maps to `off` by default.
 
+### SoftwareUpdate
+
+The Software Update trait is used for devices that can have a software update.  It can be controlled by saying things like "Hey Google, Software update {device}." and queried by saying things like "Hey Google, When was {device} last updated?".  It has the following configuration parameters:
+
+- Last Software Update Unix Time Stamp Attribute: The device attribute used to indicate the last Unix time (in seconds) that the update occurred.  Maps to `lastSoftwareUpdateUnixTimestamp` by default.
+- Software Update Command: A device command used to start a software update on the device.  Maps to `softwareUpdate` by default.
+
 ### Start/Stop
 
-This trait is used for devices that support starting, stopping, and optionally pausing operation.  It has the following configuration paramters:
+This trait is used for devices that support starting, stopping, and optionally pausing operation.  It has the following configuration parameters:
 
 - Start/Stop Attribute: The device attribute used to determine if the is currently running.  Maps to `status` by default.
 - Start Value: The value of the "Start/Stop Attribute" that indicates that the device is running.  Defaults to "running".
@@ -298,6 +338,22 @@ The following settings are only available if "Query Only Temperature Setting" is
 - Temperature Buffer: The minimum offset between the heating and cooling setpoints when in Heat/Cool mode.  Not available unless Heat/Cool mode is supported.  Optional.
 - Minimum Setpoint: The minimum allowed value for the device's setpoint.  Optional, but must be specified if Maximum Setpoint is specified.
 - Maximum Setpoint: The maximum allowed value for the device's setpoint.  Optional, but must be specified if Minimum Setpoint is specified.
+
+### Timer
+
+The Timer trait can be used to control a built-in timer on devices, such as starting a new timer as well as pausing and canceling a running timer, and asking how much time is remaining.  It can be controlled by saying things like "Hey Google, Run {device} timer for five minutes.", "Hey Google, Add one minute to {device} timer.", "Hey Google, Pause the {device} timer.", "Hey Google, Resume the {device} timer.", or "Hey Google, Stop the {device} timer."  NOTE:  Control command phrases are unconfirmed.
+And queried by saying things like "Hey Google, How much time is left on {device} timer?".  This trait has the following configuration parameters:
+
+- Command Only (No Query): Set to indicate that this device can only accept commands and not be queried for status.  Defaults to 'false'.
+- Maximum Timer Duration (seconds): The maximum seconds a timer can be set for.  Defaults to '86400'. (24 hours)
+- Time Remaining Attribute: The device attribute used to query the current timer remaining of the device.  Will be -1 (timer stopped) to Maximum Timer Duration (seconds).  Maps to the `timeRemaining` attribute by default.
+- Timer Paused Attribute: The device attribute used to query if the device is paused.  Maps to the `sessionStatus` attribute by default.
+- Timer Paused Value: The value that the Timer Paused Attribute will report when the device is paused.  Defaults to `paused`.
+- Timer Start Command: A device command used to start the device timer.  A parameter of timerTimeSec with the number of seconds between 0 and Maximum Timer Duration (seconds) will be supplied.  Maps to `startTimer` by default.
+- Timer Adjust Command: A device command used to adjust the device timer.  A parameter of timerTimeSec with the number of +/- seconds to adjust the timer to will supplied.  Maps to `setTimeRemaining` by default.
+- Timer Cancel Command: A device command used to pause the device timer.  Maps to `cancel` by default.
+- Timer Pause Command: A device command used to pause the device timer.  Maps to `pause` by default.
+- Timer Resume Command: A device command used to pause the device timer.  Maps to `start` by default.
 
 ### Toggles
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The Energy Storage trait is used for any device that can report energy capacity 
 - Capacity Remaining Unit: The unit represented by the Capacity Remaining Value Attribute.  Defaults to 'PERCENT'.
 - Capacity Until Full Value Attribute: The device attribute used to query the capacity until full of the device.
 - Capacity Until Full Unit: The unit represented by the Capacity Until Full Value Value Attribute.
-- Descriptive Capacity Remaining Attribute: The device attribute used to query the current capacity of the device with descriptive text should no number capacity remaining value be reported.  Maps to the `descriptiveCapacityRemaining` attribute by default.
+- Descriptive Capacity Remaining Attribute: The device attribute used to query the current capacity of the device with descriptive text should no number capacity remaining value be reported.
 - Charging Attribute: The device attribute used to query the current charging state of the device.
 - Charging Value: The value that the Charging attribute will report when the device is charging.
 - Plugged In Attribute: The device attribute used to query the current plugged in state of the device.

--- a/README.md
+++ b/README.md
@@ -171,18 +171,17 @@ The Energy Storage trait is used for any device that can report energy capacity 
 "Hey Google, What is {device} battery percentage?", or "Hey Google, How long until {device} is fully charged?"  This trait has the following configuration parameters:
 
 - Rechargeable: Set to indicate that this device is rechargeable.  Defaults to 'false'.
-- Query Only Energy Storage: Set to indicate that this device can only be queried for energy storage and not controlled.
-- Supported Distance Units: Set to indicate that units the UI will use if the configured units are set to distance.
+- Query Only Energy Storage: Set to indicate that this device can only be queried for energy storage and not controlled.  If 'true', the following command is available:
+    - Charge Command: A device command used to charge the device.
+- Capacity Remaining Value Attribute: The device attribute used to query the current capacity of the device.  Maps to the `battery` attribute by default.
+- Capacity Remaining Unit: The unit represented by the Capacity Remaining Value Attribute.  Defaults to 'PERCENT'.
+- Capacity Until Full Value Attribute: The device attribute used to query the capacity until full of the device.
+- Capacity Until Full Unit: The unit represented by the Capacity Until Full Value Value Attribute.
 - Descriptive Capacity Remaining Attribute: The device attribute used to query the current capacity of the device with descriptive text should no number capacity remaining value be reported.  Maps to the `descriptiveCapacityRemaining` attribute by default.
-- Capacity Remaining Value Attribute: The device attribute used to query the current capacity of the device.  Maps to the `capacityRemainingRawValue` attribute by default.
-- Capacity Remaining Unit Attribute: The device attribute used to indicate the units for Capacity Remaining Value Attribute.  Typical useful unit will be 'PERCENT'. 
-- Capacity Until Full Value Attribute: The device attribute used to query the capacity until full of the device.  Maps to the `capacityUntilFullRawValue` attribute by default.
-- Capacity Remaining Unit Attribute: The device attribute used to indicate the units for Capacity Until Full Value Value Attribute.  Typical useful unit will be 'SECONDS'.  
-- Charging Attribute: The device attribute used to query the current charging state of the device.  Maps to the `isCharging` attribute by default.
-- Charging Value: The value that the Charging attribute will report when the device is charging.  Defaults to 'true'.
-- Plugged In Attribute: The device attribute used to query the current plugged in state of the device.  Maps to the `isPluggedIn` attribute by default.
-- Plugged In Value: The value that the Plugged In attribute will report when the device is plugged in.  Defaults to 'true'.
-- Charge Command: A device command used to charge the device.  Maps to `charge` by default.
+- Charging Attribute: The device attribute used to query the current charging state of the device.
+- Charging Value: The value that the Charging attribute will report when the device is charging.
+- Plugged In Attribute: The device attribute used to query the current plugged in state of the device.
+- Plugged In Value: The value that the Plugged In attribute will report when the device is plugged in.
 
 ### Fan Speed
 
@@ -227,10 +226,10 @@ The Lock/Unlock trait is used for anything that can lock and unlock, such as doo
 
 The Media State trait is used for reporting the current playback and activity state of a media device.  Query command is unknown at the is time.  The trait has the following configuration parameters:
 
-- Support Activity State: Should be set if this device can report the current activity state.  Defaults to 'false'.
-- Support Playback State: Should be set if this device can report the current playback state.  Defaults to 'false'.
-- Activity State Attribute: The device attribute used to query the current activity state of the device.  Maps to the `activityState` attribute by default.
-- Playback State Attribute: The device attribute used to query the current playback state of the device.  Maps to the `playbackState` attribute by default.
+- Support Activity State: Should be set if this device can report the current activity state.  Defaults to 'false'.  If 'true', the following state is available:
+    - Activity State Attribute: The device attribute used to query the current activity state of the device.
+- Support Playback State: Should be set if this device can report the current playback state.  Defaults to 'false'.  If 'true', the following state is available:
+    - Playback State Attribute: The device attribute used to query the current playback state of the device.  Maps to the `status` attribute by default.
 
 ### On/Off
 
@@ -268,7 +267,7 @@ The Open/Close trait is used for devices that can be opened and closed such as d
 
 The Reboot trait is used for devices that can be rebooted.  It can be controlled by saying things like "Hey Google, reboot {device}".  It has the following configuration parameters:
 
-- Reboot Command: A device command to reboot the device.  Maps to `reboot` by default.
+- Reboot Command: A device command to reboot the device.
 
 ### Rotation
 
@@ -290,8 +289,8 @@ This is used for controlling scenes, and should generally only be used with the 
 
 The Software Update trait is used for devices that can have a software update.  It can be controlled by saying things like "Hey Google, Software update {device}." and queried by saying things like "Hey Google, When was {device} last updated?".  It has the following configuration parameters:
 
-- Last Software Update Unix Time Stamp Attribute: The device attribute used to indicate the last Unix time (in seconds) that the update occurred.  Maps to `lastSoftwareUpdateUnixTimestamp` by default.
-- Software Update Command: A device command used to start a software update on the device.  Maps to `softwareUpdate` by default.
+- Last Software Update Unix Time Stamp Attribute: The device attribute used to indicate the last Unix time (in seconds) that the update occurred.
+- Software Update Command: A device command used to start a software update on the device.
 
 ### Start/Stop
 
@@ -344,16 +343,16 @@ The following settings are only available if "Query Only Temperature Setting" is
 The Timer trait can be used to control a built-in timer on devices, such as starting a new timer as well as pausing and canceling a running timer, and asking how much time is remaining.  It can be controlled by saying things like "Hey Google, Run {device} timer for five minutes.", "Hey Google, Add one minute to {device} timer.", "Hey Google, Pause the {device} timer.", "Hey Google, Resume the {device} timer.", or "Hey Google, Stop the {device} timer."  NOTE:  Control command phrases are unconfirmed.
 And queried by saying things like "Hey Google, How much time is left on {device} timer?".  This trait has the following configuration parameters:
 
-- Command Only (No Query): Set to indicate that this device can only accept commands and not be queried for status.  Defaults to 'false'.
 - Maximum Timer Duration (seconds): The maximum seconds a timer can be set for.  Defaults to '86400'. (24 hours)
-- Time Remaining Attribute: The device attribute used to query the current timer remaining of the device.  Will be -1 (timer stopped) to Maximum Timer Duration (seconds).  Maps to the `timeRemaining` attribute by default.
-- Timer Paused Attribute: The device attribute used to query if the device is paused.  Maps to the `sessionStatus` attribute by default.
-- Timer Paused Value: The value that the Timer Paused Attribute will report when the device is paused.  Defaults to `paused`.
-- Timer Start Command: A device command used to start the device timer.  A parameter of timerTimeSec with the number of seconds between 0 and Maximum Timer Duration (seconds) will be supplied.  Maps to `startTimer` by default.
+- Command Only (No Query): Set to indicate that this device can only accept commands and not be queried for status.  Defaults to 'false'.  If 'true', the following parameters are available:
+    - Time Remaining Attribute: The device attribute used to query the current timer remaining of the device.  Will be -1 (timer stopped) to Maximum Timer Duration (seconds).  Maps to the `timeRemaining` attribute by default.
+    - Timer Paused Attribute: The device attribute used to query if the device is paused.  Maps to the `sessionStatus` attribute by default.
+    - Timer Paused Value: The value that the Timer Paused Attribute will report when the device is paused.  Defaults to `paused`.
+- Timer Start Command: A device command used to start the device timer.  A parameter of timerTimeSec with the number of seconds between 0 and Maximum Timer Duration (seconds) will be supplied.  Maps to `start` by default.
 - Timer Adjust Command: A device command used to adjust the device timer.  A parameter of timerTimeSec with the number of +/- seconds to adjust the timer to will supplied.  Maps to `setTimeRemaining` by default.
-- Timer Cancel Command: A device command used to pause the device timer.  Maps to `cancel` by default.
+- Timer Cancel Command: A device command used to cancel the device timer.  Maps to `cancel` by default.
 - Timer Pause Command: A device command used to pause the device timer.  Maps to `pause` by default.
-- Timer Resume Command: A device command used to pause the device timer.  Maps to `start` by default.
+- Timer Resume Command: A device command used to resume the device timer.  Maps to `start` by default.
 
 ### Toggles
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The Energy Storage trait is used for any device that can report energy capacity 
 - Query Only Energy Storage: Set to indicate that this device can only be queried for energy storage and not controlled.  If 'true', the following command is available:
     - Charge Command: A device command used to charge the device.
 - Capacity Remaining Value Attribute: The device attribute used to query the current capacity of the device.  Maps to the `battery` attribute by default.
-- Capacity Remaining Unit: The unit represented by the Capacity Remaining Value Attribute.  Defaults to 'PERCENT'.
+- Capacity Remaining Unit: The unit represented by the Capacity Remaining Value Attribute.  Defaults to 'PERCENTAGE'.
 - Capacity Until Full Value Attribute: The device attribute used to query the capacity until full of the device.
 - Capacity Until Full Unit: The unit represented by the Capacity Until Full Value Value Attribute.
 - Descriptive Capacity Remaining Attribute: The device attribute used to query the current capacity of the device with descriptive text should no number capacity remaining value be reported.

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2447,8 +2447,7 @@ private deviceStateForTrait_Dock(deviceTrait, device) {
 private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
     def deviceState = [:]
     if (deviceTrait.descriptiveCapacityRemainingAttribute != null) {
-        deviceState.descriptiveCapacityRemaining
-            = device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
+        deviceState.descriptiveCapacityRemaining = device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
     }
     deviceState.capacityRemaining = [
         [
@@ -2467,8 +2466,7 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
             deviceState.isCharging = device.currentValue(deviceTrait.isChargingAttribute) == deviceTrait.chargingValue
         }
         if (deviceTrait.pluggedInValue != null) {
-            deviceState.isPluggedIn
-                = device.currentValue(deviceTrait.isPluggedInAttribute) == deviceTrait.pluggedInValue
+            deviceState.isPluggedIn = device.currentValue(deviceTrait.isPluggedInAttribute) == deviceTrait.pluggedInValue
         }
     }
 

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -618,7 +618,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             submitOnChange: true
         )
     }
-    section(hidable: true, hidden: true, "Advanced Settings") {
+    section(hideable: true, hidden: true, "Advanced Settings") {
         input(
             name: "${deviceTrait.name}.queryOnlyEnergyStorage",
             title: "Query Only Energy Storage",

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2443,7 +2443,7 @@ private deviceStateForTrait_Dock(deviceTrait, device) {
     ]
 }
 
-@SuppressWarnings(['UnusedPrivateMethod', 'LineLength'])
+@SuppressWarnings('UnusedPrivateMethod')
 private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
     def deviceState = [:]
     if (deviceTrait.descriptiveCapacityRemainingAttribute != null) {
@@ -2463,10 +2463,12 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
             ]
         }
         if (deviceTrait.chargingValue != null) {
-            deviceState.isCharging = device.currentValue(deviceTrait.isChargingAttribute) == deviceTrait.chargingValue
+            deviceState.isCharging =
+                device.currentValue(deviceTrait.isChargingAttribute) == deviceTrait.chargingValue
         }
         if (deviceTrait.pluggedInValue != null) {
-            deviceState.isPluggedIn = device.currentValue(deviceTrait.isPluggedInAttribute) == deviceTrait.pluggedInValue
+            deviceState.isPluggedIn =
+                device.currentValue(deviceTrait.isPluggedInAttribute) == deviceTrait.pluggedInValue
         }
     }
 

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -46,7 +46,10 @@
 //   * Jan 19 2021 - Added Dock and StartStop Traits
 //   * Jan 31 2021 - Don't break the whole app if someone creates an invalid toggle
 //   * Feb 28 2021 - Add new device types supported by Google
-//   * Apr 18 2021 - Added Locator Traits
+//   * Apr 18 2021 - Added Locator Trait
+//   * Apr 23 2021 - Added Energy Storage, Software Update, Reboot, Media State (query untested) and 
+//                   Timer (commands untested) Traits.  Added missing camera trait protocol attributes.
+
 
 import groovy.json.JsonException
 import groovy.json.JsonOutput
@@ -421,6 +424,12 @@ private deviceTraitPreferences_Brightness(deviceTrait) {
 
 @SuppressWarnings('UnusedPrivateMethod')
 def deviceTraitPreferences_CameraStream(deviceTrait) {
+    googleCameraStreamSupportedProtocols = [
+        "progressive_mp4":         "Progressive MP4",
+        "hls":                     "HLS",        
+        "dash":                    "Dash",
+        "smooth_stream":           "Smooth Stream",      
+    ]          
     section("Stream Camera") {
         input(
             name: "${deviceTrait.name}.cameraStreamAttribute",
@@ -429,6 +438,14 @@ def deviceTraitPreferences_CameraStream(deviceTrait) {
             defaultValue: "settings",
             required: true
         )
+        input(
+            name: "${deviceTrait.name}.cameraStreamSupportedProtocols",
+            title: "Camera Stream Supported Protocols",
+            type: "enum",
+            options: googleCameraStreamSupportedProtocols,
+            multiple: true,
+            required: true,
+        )                         
     }
 }
 
@@ -560,6 +577,126 @@ private deviceTraitPreferences_Dock(deviceTrait) {
             required: true
         )
     }
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
+private deviceTraitPreferences_EnergyStorage(deviceTrait) {
+    googleEnergyStorageDistanceUnitForUX = [
+        "KILOMETERS":      "Kilometers",
+        "MILES":           "Miles",
+    ]     
+    googleCapacityUnits = [
+        "SECONDS":         "Seconds",
+        "MILES":           "Miles",        
+        "KILOMETERS":      "Kilometers",
+        "PERCENTAGE":      "Percentage",
+        "KILOWATT_HOURS":  "Kilowatt Hours",        
+    ]      
+    section("Energy Storage Settings") {
+        input(
+            name: "${deviceTrait.name}.isRechargeable",
+            title: "Rechargeable",
+            type: "bool",
+            defaultValue: false,
+            required: true,            
+            submitOnChange: true
+        )
+        input(
+            name: "${deviceTrait.name}.queryOnlyEnergyStorage",
+            title: "Query Only Energy Storage",
+            type: "bool",
+            defaultValue: false,
+            required: true,
+            submitOnChange: true
+        )
+        if (!deviceTrait.queryOnlyEnergyStorage) {
+            input(
+                name: "${deviceTrait.name}.chargeCommand",
+                title: "Charge Command",
+                type: "text",
+                defaultValue: "charge",
+                required: true
+            )
+        }        
+        input(
+            name: "${deviceTrait.name}.descriptiveCapacityRemainingAttribute",
+            title: "Descriptive Capacity Remaining",
+            type: "text",
+            defaultValue: "descriptiveCapacityRemaining",
+            required: true
+        )          
+        input(
+            name: "${deviceTrait.name}.capacityRemainingRawValue",
+            title: "Capacity Remaining Value",
+            type: "text",
+            defaultValue: "capacityRemainingRawValue",
+            required: true
+        )     
+        input(
+            name: "${deviceTrait.name}.capacityRemainingUnit",
+            title: "Capacity Remaining Unit",
+            type: "enum",
+            options: googleCapacityUnits,
+            multiple: false,
+            required: true,
+            submitOnChange: true
+        )            
+        input(
+            name: "${deviceTrait.name}.capacityUntilFullRawValue",
+            title: "Capacity Until Full Value",
+            type: "text",
+            defaultValue: "capacityUntilFullRawValue",
+            required: true
+        )     
+        input(
+            name: "${deviceTrait.name}.capacityUntilFullUnit",
+            title: "Capacity Until Full Unit",
+            type: "enum",
+            options: googleCapacityUnits,
+            multiple: false,
+            required: true,
+            submitOnChange: true
+        )              
+        input(
+            name: "${deviceTrait.name}.isChargingAttribute",
+            title: "Charging Attribute",
+            type: "text",
+            defaultValue: "isCharging",
+            required: true
+        )
+        input(
+            name: "${deviceTrait.name}.chargingValue",
+            title: "Charging Value",
+            type: "text",
+            defaultValue: "true",
+            required: true
+        )        
+        input(
+            name: "${deviceTrait.name}.isPluggedInAttribute",
+            title: "ve",
+            type: "text",
+            defaultValue: "isPluggedIn",
+            required: true
+        )  
+        input(
+            name: "${deviceTrait.name}.pluggedInValue",
+            title: "Plugged In Value",
+            type: "text",
+            defaultValue: "true",
+            required: true
+        )    
+        if ((deviceTrait.capacityRemainingUnit == "MILES") || (deviceTrait.capacityRemainingUnit == "KILOMETERS") || (deviceTrait.capacityUntilFullUnit == "MILES") || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {        
+            input(
+                name: "${deviceTrait.name}.energyStorageDistanceUnitForUX",
+                title: "Supported Distance Units",
+                type: "enum",
+                options: googleEnergyStorageDistanceUnitForUX,
+                multiple: false,
+                required: true,
+                submitOnChange: true
+            )     
+        }        
+    }    
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -727,6 +864,40 @@ private deviceTraitPreferences_LockUnlock(deviceTrait) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+private deviceTraitPreferences_MediaState(deviceTrait) {
+    section("Media State Settings") {
+        input(
+            name: "${deviceTrait.name}.supportActivityState",
+            title: "Support Activity State",
+            type: "bool",
+            defaultValue: false,
+            required: true,
+        )
+        input(
+            name: "${deviceTrait.name}.supportPlaybackState",
+            title: "Support Playback State",
+            type: "bool",
+            defaultValue: false,
+            required: true,
+        )
+        input(
+            name: "${deviceTrait.name}.activityStateAttribute",
+            title: "Activity State Attribute",
+            type: "text",
+            defaultValue: "activityState",
+            required: true
+        )
+        input(
+            name: "${deviceTrait.name}.playbackStateAttribute",
+            title: "Playback State Attribute",
+            type: "text",
+            defaultValue: "playbackState",
+            required: true
+        )
+    }
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
 private deviceTraitPreferences_OnOff(deviceTrait) {
     section("On/Off Settings") {
         input(
@@ -880,6 +1051,19 @@ private deviceTraitPreferences_OpenClose(deviceTrait) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+def deviceTraitPreferences_Reboot(deviceTrait) {
+    section("Reboot Preferences") {
+        input(
+            name: "${deviceTrait.name}.rebootCommand",
+            title: "Reboot Command",
+            type: "text",
+            defaultValue: "reboot",        
+            required: true
+        )
+    }
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
 def deviceTraitPreferences_Rotation(deviceTrait) {
     section("Rotation Preferences") {
         input(
@@ -930,6 +1114,26 @@ def deviceTraitPreferences_Scene(deviceTrait) {
                 required: true
             )
         }
+    }
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
+def deviceTraitPreferences_SoftwareUpdate(deviceTrait) {
+    section("Software Update Settings") {
+        input(
+            name: "${deviceTrait.name}.lastSoftwareUpdateUnixTimestampSecAttribute",
+            title: "Last Software Update Unix Timestamp in Seconds Attribute",
+            type: "text",
+            defaultValue: "lastSoftwareUpdateUnixTimestamp",
+            required: true
+        )        
+        input(
+            name: "${deviceTrait.name}.softwareUpdateCommand",
+            title: "Software Update Command",
+            type: "text",
+            defaultValue: "softwareUpdate", 
+            required: true
+        )
     }
 }
 
@@ -1255,6 +1459,85 @@ private temperatureSettingControlPreferences(deviceTrait) {
         required: settings."${deviceTrait.name}.range.min" != null,
         submitOnChange: true
     )
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
+private deviceTraitPreferences_Timer(deviceTrait) {
+    section("Timer Settings") {
+        input(
+            name: "${deviceTrait.name}.commandOnlyTimer",
+            title: "Command Only (No Query)",
+            type: "bool",
+            required: true,
+            defaultValue: false,
+            submitOnChange: true,
+        )          
+        input(
+            name: "${deviceTrait.name}.maxTimerLimitSec",
+            title: "Maximum Timer Duration (seconds)",
+            type: "integer",
+            required: true,
+            defaultValue: "86400"
+        )    
+        if (!deviceTrait.commandOnlyTimer) {
+            input(
+                name: "${deviceTrait.name}.timerRemainingSecAttribute",
+                title: "Time Remaining Attribute",
+                type: "text",
+                required: true,
+                defaultValue: "timeRemaining"
+            )        
+            input(
+                name: "${deviceTrait.name}.timerPausedAttribute",
+                title: "Timer Paused Attribute",
+                type: "text",
+                required: true,
+                defaultValue: "sessionStatus"
+            )      
+            input(
+                name: "${deviceTrait.name}.timerPausedValue",
+                title: "Timer Paused Value",
+                type: "text",
+                required: true,
+                defaultValue: "paused"
+            )          
+        }       
+        input(
+            name: "${deviceTrait.name}.timerStartCommand",
+            title: "Timer Start Command",
+            type: "text",
+            required: true,
+            defaultValue: "startTimer"
+        )            
+        input(
+            name: "${deviceTrait.name}.timerAdjustCommand",
+            title: "Timer Adjust Command",
+            type: "text",
+            required: true,
+            defaultValue: "setTimeRemaining"
+        )     
+        input(
+            name: "${deviceTrait.name}.timerCancelCommand",
+            title: "Timer Cancel Command",
+            type: "text",
+            required: true,
+            defaultValue: "cancel"
+        )     
+        input(
+            name: "${deviceTrait.name}.timerPauseCommand",
+            title: "Timer Pause Command",
+            type: "text",
+            required: true,
+            defaultValue: "pause"
+        )     
+        input(
+            name: "${deviceTrait.name}.timerResumeCommand",
+            title: "Timer Resume Command",
+            type: "text",
+            required: true,
+            defaultValue: "start"
+        )                  
+    }
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -1673,6 +1956,14 @@ private executeCommand_Dock(deviceInfo, command) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+private executeCommand_Charge(deviceInfo, command) {
+    checkMfa(deviceInfo.deviceType, "Charge", command)
+    def energyStorageTrait = deviceInfo.deviceType.traits.EnergyStorage
+    deviceInfo.device."${energyStorageTrait.chargeCommand}"()
+    return [:]
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_Reverse(deviceInfo, command) {
     checkMfa(deviceInfo.deviceType, "Reverse", command)
     def fanSpeedTrait = deviceInfo.deviceType.traits.FanSpeed
@@ -1789,6 +2080,14 @@ private executeCommand_OpenClose(deviceInfo, command) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+private executeCommand_Reboot(deviceInfo, command) {
+    checkMfa(deviceInfo.deviceType, "Reboot", command)
+    def rebootTrait = deviceInfo.deviceType.traits.Reboot
+    deviceInfo.device."${rebootTrait.rebootCommand}"()
+    return [:]
+} 
+
+@SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_RotateAbsolute(deviceInfo, command) {
     checkMfa(deviceInfo.deviceType, "Rotate", command)
     def rotationTrait = deviceInfo.deviceType.traits.Rotation
@@ -1798,7 +2097,7 @@ private executeCommand_RotateAbsolute(deviceInfo, command) {
     return [
         (rotationTrait.rotationAttribute): position
     ]
-}
+} 
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_SetFanSpeed(deviceInfo, command) {
@@ -1874,6 +2173,14 @@ private executeCommand_setVolume(deviceInfo, command) {
         (volumeTrait.volumeAttribute): volumeLevel
     ]
 }
+
+@SuppressWarnings('UnusedPrivateMethod')
+private executeCommand_SoftwareUpdate(deviceInfo, command) {
+    checkMfa(deviceInfo.deviceType, "SoftwareUpdate", command)
+    def softwareUpdateTrait = deviceInfo.deviceType.traits.SoftwareUpdate
+    deviceInfo.device."${softwareUpdateTrait.softwareUpdateCommand}"()
+    return [:]
+} 
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_StartStop(deviceInfo, command) {
@@ -1961,6 +2268,58 @@ private executeCommand_ThermostatSetMode(deviceInfo, command) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+private executeCommand_TimerAdjust(deviceInfo, command) {
+    checkMfa(deviceInfo.deviceType, "TimerAdjust", command)
+    def TimerTrait = deviceInfo.deviceType.traits.Timer
+    deviceInfo.device."${TimerTrait.timerAdjustCommand}"()
+    def retVal = [:]
+    if (!deviceTrait.commandOnlyTimer) {
+        retVal= [
+            timerTimeSec: device.currentValue(timerTrait.timerRemainingSecAttribute)
+        ]
+    }
+    return retVal
+} 
+
+@SuppressWarnings('UnusedPrivateMethod')
+private executeCommand_TimerCancel(deviceInfo, command) {
+    checkMfa(deviceInfo.deviceType, "TimerCancel", command)
+    def TimerTrait = deviceInfo.deviceType.traits.Timer
+    deviceInfo.device."${TimerTrait.timerCancelCommand}"()
+    return [:]
+} 
+
+@SuppressWarnings('UnusedPrivateMethod')
+private executeCommand_TimerPause(deviceInfo, command) {
+    checkMfa(deviceInfo.deviceType, "TimerPause", command)
+    def TimerTrait = deviceInfo.deviceType.traits.Timer
+    deviceInfo.device."${TimerTrait.timerPauseCommand}"()
+    return [:]
+} 
+
+@SuppressWarnings('UnusedPrivateMethod')
+private executeCommand_TimerResume(deviceInfo, command) {
+    checkMfa(deviceInfo.deviceType, "TimerResume", command)
+    def TimerTrait = deviceInfo.deviceType.traits.Timer
+    deviceInfo.device."${TimerTrait.timerResumeCommand}"()
+    return [:]
+} 
+
+@SuppressWarnings('UnusedPrivateMethod')
+private executeCommand_TimerStart(deviceInfo, command) {
+    checkMfa(deviceInfo.deviceType, "TimerStart", command)
+    def TimerTrait = deviceInfo.deviceType.traits.Timer
+    deviceInfo.device."${TimerTrait.timerStartCommand}"()
+    def retVal = [:]
+    if (!deviceTrait.commandOnlyTimer) {
+        retVal= [
+            timerTimeSec: device.currentValue(timerTrait.timerRemainingSecAttribute)
+        ]
+    }
+    return retVal
+} 
+
+@SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_volumeRelative(deviceInfo, command) {
     checkMfa(deviceInfo.deviceType, "Set Volume", command)
     def volumeTrait = deviceInfo.deviceType.traits.Volume
@@ -2030,9 +2389,10 @@ private deviceStateForTrait_Brightness(deviceTrait, device) {
 @SuppressWarnings(['UnusedPrivateMethod', 'UnusedPrivateMethodParameter'])
 private deviceStateForTrait_CameraStream(deviceTrait, device) {
     return [
-        cameraStreamAccessUrl: device.currentValue(deviceTrait.cameraStreamAttribute),
-        cameraStreamReceiverAppId: null,
-        cameraStreamAuthToken: null
+        cameraStreamAccessUrl:        device.currentValue(deviceTrait.cameraStreamAttribute),
+        cameraStreamReceiverAppId:    null,
+        cameraStreamAuthToken:        null,
+        cameraStreamProtocol:         deviceTrait.cameraStreamSupportedProtocols
     ]
 }
 
@@ -2092,6 +2452,29 @@ private deviceStateForTrait_Dock(deviceTrait, device) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
+    def deviceState = [
+        descriptiveCapacityRemaining: device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
+    ]
+    deviceState.capacityRemaining = [
+        [
+            rawValue: device.currentValue(deviceTrait.capacityRemainingRawValue).toInteger(),
+            unit:     deviceTrait.capacityRemainingUnit
+        ]
+    ]    
+    deviceState.capacityUntilFull = [
+        [
+            rawValue: device.currentValue(deviceTrait.capacityUntilFullRawValue).toInteger(),
+            unit:     deviceTrait.capacityUntilFullUnit      
+        ]       
+    ]
+    deviceState.isCharging = device.currentValue(deviceTrait.isChargingAttribute) == deviceTrait.chargingValue
+    deviceState.isPluggedIn = device.currentValue(deviceTrait.isPluggedInAttribute) == deviceTrait.pluggedInValue
+       
+    return deviceState  
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
 private deviceStateForTrait_FanSpeed(deviceTrait, device) {
     def currentSpeed = device.currentValue(deviceTrait.currentSpeedAttribute)
 
@@ -2126,6 +2509,14 @@ private deviceStateForTrait_LockUnlock(deviceTrait, device) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+private deviceStateForTrait_MediaState(deviceTrait, device) {
+    return [
+        activityState: device.currentValue(deviceTrait.activityStateAttribute),
+        playbackState: device.currentValue(deviceTrait.playbackStateAttribute)
+    ]
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
 private deviceStateForTrait_OnOff(deviceTrait, device) {
     def isOn
     if (deviceTrait.onValue) {
@@ -2156,6 +2547,11 @@ private deviceStateForTrait_OpenClose(deviceTrait, device) {
     ]
 }
 
+@SuppressWarnings(['UnusedPrivateMethod', 'UnusedPrivateMethodParameter'])
+private deviceStateForTrait_Reboot(deviceTrait, device) {
+    return [:]
+}
+
 @SuppressWarnings('UnusedPrivateMethod')
 private deviceStateForTrait_Rotation(deviceTrait, device) {
     return [
@@ -2166,6 +2562,13 @@ private deviceStateForTrait_Rotation(deviceTrait, device) {
 @SuppressWarnings(['UnusedPrivateMethod', 'UnusedPrivateMethodParameter'])
 private deviceStateForTrait_Scene(deviceTrait, device) {
     return [:]
+}
+
+@SuppressWarnings(['UnusedPrivateMethod', 'UnusedPrivateMethodParameter'])
+private deviceStateForTrait_SoftwareUpdate(deviceTrait, device) {
+    return [
+        lastSoftwareUpdateUnixTimestampSec: device.currentValue(deviceTrait.lastSoftwareUpdateUnixTimestampSecAttribute).toInteger()
+    ]
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -2246,6 +2649,23 @@ private deviceStateForTrait_TemperatureSetting(deviceTrait, device) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+private deviceStateForTrait_Timer(deviceTrait, device) {
+    def deviceState = [:]
+    if (!deviceTrait.commandOnlyTimer) {       
+        deviceState = [
+            timerRemainingSec: device.currentValue(deviceTrait.timerRemainingSecAttribute),
+            timerPaused: device.currentValue(deviceTrait.timerPausedAttribute) == deviceTrait.timerPausedValue     
+        ]
+    } else {
+        // report no running timers
+        deviceState = [
+            timerRemainingSec: -1   
+        ]
+    }
+    return deviceState
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
 private deviceStateForTrait_Toggles(deviceTrait, device) {
     return [
         currentToggleSettings: deviceTrait.toggles.collectEntries { toggle ->
@@ -2308,7 +2728,7 @@ private attributesForTrait_Brightness(deviceTrait) {
 @SuppressWarnings(['UnusedPrivateMethod', 'UnusedPrivateMethodParameter'])
 private attributesForTrait_CameraStream(deviceTrait) {
     return [
-        cameraStreamSupportedProtocols: ["progressive_mp4", "hls", "dash", "smooth_stream"],
+        cameraStreamSupportedProtocols: deviceTrait.cameraStreamSupportedProtocols,
         cameraStreamNeedAuthToken:      false,
         cameraStreamNeedDrmEncryption:  false
     ]
@@ -2336,6 +2756,15 @@ private attributesForTrait_ColorSetting(deviceTrait) {
 @SuppressWarnings(['UnusedPrivateMethod', 'UnusedPrivateMethodParameter'])
 private attributesForTrait_Dock(deviceTrait) {
     return [:]
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
+private attributesForTrait_EnergyStorage(deviceTrait) {
+    return [
+        queryOnlyEnergyStorage:         deviceTrait.queryOnlyEnergyStorage,
+        energyStorageDistanceUnitForUX: deviceTrait.energyStorageDistanceUnitForUX,
+        isRechargeable:                 deviceTrait.isRechargeable
+    ]    
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -2387,6 +2816,14 @@ private attributesForTrait_LockUnlock(deviceTrait) {
     return [:]
 }
 
+@SuppressWarnings('UnusedPrivateMethod')
+private attributesForTrait_MediaState(deviceTrait) {
+    return [
+        supportActivityState: deviceTrait.supportActivityState,
+        supportPlaybackState: deviceTrait.supportPlaybackState
+    ]
+}
+
 @SuppressWarnings(['UnusedPrivateMethod', 'UnusedPrivateMethodParameter'])
 private attributesForTrait_OnOff(deviceTrait) {
     return [:]
@@ -2398,6 +2835,11 @@ private attributesForTrait_OpenClose(deviceTrait) {
         discreteOnlyOpenClose: deviceTrait.discreteOnlyOpenClose,
         queryOnlyOpenClose: deviceTrait.queryOnly
     ]
+}
+
+@SuppressWarnings(['UnusedPrivateMethod', 'UnusedPrivateMethodParameter'])
+private attributesForTrait_Reboot(deviceTrait) {
+    return [:]
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -2414,6 +2856,11 @@ private attributesForTrait_Scene(deviceTrait) {
     return [
         sceneReversible: deviceTrait.sceneReversible
     ]
+}
+
+@SuppressWarnings(['UnusedPrivateMethod', 'UnusedPrivateMethodParameter'])
+private attributesForTrait_SoftwareUpdate(deviceTrait) {
+    return [:]
 }
 
 @SuppressWarnings(['UnusedPrivateMethod', 'UnusedPrivateMethodParameter'])
@@ -2491,6 +2938,14 @@ private attributesForTrait_TemperatureSetting(deviceTrait) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+private attributesForTrait_Timer(deviceTrait) {
+    return [
+        maxTimerLimitSec:    deviceTrait.maxTimerLimitSec,
+        commandOnlyTimer:    deviceTrait.commandOnlyTimer,
+    ]
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
 private attributesForTrait_Toggles(deviceTrait) {
     return [
         availableToggles: deviceTrait.toggles.collect { toggle ->
@@ -2528,7 +2983,8 @@ private traitFromSettings_Brightness(traitName) {
 @SuppressWarnings('UnusedPrivateMethod')
 private traitFromSettings_CameraStream(traitName) {
     return [
-        cameraStreamAttribute: settings."${traitName}.cameraStreamAttribute",
+        cameraStreamAttribute:          settings."${traitName}.cameraStreamAttribute",
+        cameraStreamSupportedProtocols: settings."${traitName}.cameraStreamSupportedProtocols",   
         commands:              []
     ]
 }
@@ -2576,6 +3032,31 @@ private traitFromSettings_Dock(traitName) {
         dockCommand:   settings."${traitName}.dockCommand",
         commands:      ["Dock"]
     ]
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
+private traitFromSettings_EnergyStorage(traitName) {
+    def energyStorageTrait = [
+        energyStorageDistanceUnitForUX:           settings."${traitName}.energyStorageDistanceUnitForUX",
+        isRechargeable:                           settings."${traitName}.isRechargeable",        
+        queryOnlyEnergyStorage:                   settings."${traitName}.queryOnlyEnergyStorage",
+        descriptiveCapacityRemainingAttribute:    settings."${traitName}.descriptiveCapacityRemainingAttribute",
+        capacityRemainingRawValue:                settings."${traitName}.capacityRemainingRawValue",
+        capacityRemainingUnit:                    settings."${traitName}.capacityRemainingUnit",
+        capacityUntilFullRawValue:                settings."${traitName}.capacityUntilFullRawValue",
+        capacityUntilFullUnit:                    settings."${traitName}.capacityUntilFullUnit",
+        isChargingAttribute:                      settings."${traitName}.isChargingAttribute",      
+        chargingValue:                            settings."${traitName}.chargingValue",     
+        isPluggedInAttribute:                     settings."${traitName}.isPluggedInAttribute",
+        pluggedInValue:                           settings."${traitName}.pluggedInValue",
+        chargeCommand:                            settings."${traitName}.chargeCommand",
+        commands:                                 []  
+    ]  
+    if (!energyStorageTrait.queryOnlyEnergyStorage) {
+        energyStorageTrait.commands += ["Charge"]
+    }
+
+    return energyStorageTrait     
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -2645,6 +3126,17 @@ private traitFromSettings_LockUnlock(traitName) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+private traitFromSettings_MediaState(traitName) {
+    return [
+        supportActivityState:     settings."${traitName}.supportActivityState",
+        supportPlaybackState:     settings."${traitName}.supportPlaybackState",
+        activityStateAttribute:   settings."${traitName}.activityStateAttribute",
+        playbackStateAttribute:   settings."${traitName}.playbackStateAttribute",
+        commands:                 []
+    ]
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
 private traitFromSettings_OnOff(traitName) {
     def deviceTrait = [
         onOffAttribute: settings."${traitName}.onOffAttribute",
@@ -2695,6 +3187,14 @@ private traitFromSettings_OpenClose(traitName) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+private traitFromSettings_Reboot(traitName) {
+    return [
+        rebootCommand:      settings."${traitName}.rebootCommand",
+        commands:           ["Reboot"]
+    ]
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
 private traitFromSettings_Rotation(traitName) {
     return [
         rotationAttribute:  settings."${traitName}.rotationAttribute",
@@ -2716,6 +3216,15 @@ private traitFromSettings_Scene(traitName) {
         sceneTrait.commands << "Deactivate Scene"
     }
     return sceneTrait
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
+private traitFromSettings_SoftwareUpdate(traitName) {
+    return [
+        lastSoftwareUpdateUnixTimestampSecAttribute:    settings."${traitName}.lastSoftwareUpdateUnixTimestampSecAttribute",        
+        softwareUpdateCommand:                          settings."${traitName}.softwareUpdateCommand",
+        commands:                                       ["Software Update"]
+    ]
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -2867,6 +3376,24 @@ private traitFromSettings_TemperatureSetting(traitName) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+private traitFromSettings_Timer(traitName) {
+    def timerTrait = [
+        maxTimerLimitSec:                 settings."${traitName}.maxTimerLimitSec",
+        commandOnlyTimer:                 settings."${traitName}.commandOnlyTimer",
+
+        commands:                         ["Start","Adjust","Cancel","Pause","Resume"]
+    ]    
+    if (!timerTrait.commandOnlyTimer) {
+        timerTrait << [
+            timerRemainingSecAttribute:   settings."${traitName}.timerRemainingSecAttribute",
+            timerPausedAttribute:         settings."${traitName}.timerPausedAttribute",
+            timerPausedValue:             settings."${traitName}.timerPausedValue",            
+        ]        
+    }
+    return timerTrait    
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
 private traitFromSettings_Toggles(traitName) {
     def togglesTrait = [
         toggles:  [],
@@ -2975,6 +3502,7 @@ private deleteDeviceTrait_Brightness(deviceTrait) {
 @SuppressWarnings('UnusedPrivateMethod')
 private deleteDeviceTrait_CameraStream(deviceTrait) {
     app.removeSetting("${deviceTrait.name}.cameraStreamAttribute")
+    app.removeSetting("${deviceTrait.name}.cameraStreamSupportedProtocols")    
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -2999,6 +3527,23 @@ private deleteDeviceTrait_Dock(deviceTrait) {
     app.removeSetting("${deviceTrait.name}.dockAttribute")
     app.removeSetting("${deviceTrait.name}.dockValue")
     app.removeSetting("${deviceTrait.name}.dockCommand")
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
+private deleteDeviceTrait_EnergyStorage(deviceTrait) {
+    app.removeSetting("${deviceTrait.name}.energyStorageDistanceUnitForUX")
+    app.removeSetting("${deviceTrait.name}.isRechargeable")
+    app.removeSetting("${deviceTrait.name}.queryOnlyEnergyStorage")
+    app.removeSetting("${deviceTrait.name}.chargeCommand")
+    app.removeSetting("${deviceTrait.name}.descriptiveCapacityRemaining")
+    app.removeSetting("${deviceTrait.name}.capacityRemainingRawValue")
+    app.removeSetting("${deviceTrait.name}.capacityRemainingUnit")
+    app.removeSetting("${deviceTrait.name}.capacityUntilFullRawValue")
+    app.removeSetting("${deviceTrait.name}.capacityUntilFullUnit")
+    app.removeSetting("${deviceTrait.name}.isChargingAttribute")  
+    app.removeSetting("${deviceTrait.name}.chargingValue")  
+    app.removeSetting("${deviceTrait.name}.isPluggedInAttribute")    
+    app.removeSetting("${deviceTrait.name}.pluggedInValue")    
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -3037,6 +3582,14 @@ private deleteDeviceTrait_LockUnlock(deviceTrait) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+private deleteDeviceTrait_MediaState(deviceTrait) {
+    app.removeSetting("${deviceTrait.name}.supportActivityState")
+    app.removeSetting("${deviceTrait.name}.supportPlaybackState")
+    app.removeSetting("${deviceTrait.name}.activityStateAttribute")
+    app.removeSetting("${deviceTrait.name}.playbackStateAttribute")
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
 private deleteDeviceTrait_OnOff(deviceTrait) {
     app.removeSetting("${deviceTrait.name}.onOffAttribute")
     app.removeSetting("${deviceTrait.name}.onValue")
@@ -3062,6 +3615,11 @@ private deleteDeviceTrait_OpenClose(deviceTrait) {
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
+private deleteDeviceTrait_Reboot(deviceTrait) {
+    app.removeSetting("${deviceTrait.name}.rebootCommand")    
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
 private deleteDeviceTrait_Rotation(deviceTrait) {
     app.removeSetting("${deviceTrait.name}.rotationAttribute")
     app.removeSetting("${deviceTrait.name}.setRotationCommand")
@@ -3073,6 +3631,12 @@ private deleteDeviceTrait_Scene(deviceTrait) {
     app.removeSetting("${deviceTrait.name}.activateCommand")
     app.removeSetting("${deviceTrait.name}.deactivateCommand")
     app.removeSetting("${deviceTrait.name}.sceneReversible")
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
+private deleteDeviceTrait_SoftwareUpdate(deviceTrait) {
+    app.removeSetting("${deviceTrait.name}.lastSoftwareUpdateUnixTimestampSecAttribute")      
+    app.removeSetting("${deviceTrait.name}.softwareUpdateCommand")          
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -3126,6 +3690,20 @@ private deleteDeviceTrait_TemperatureSetting(deviceTrait) {
     // for device types created with older versions of the app
     app.removeSetting("${deviceTrait.name}.setpointAttribute")
     app.removeSetting("${deviceTrait.name}.setSetpointCommand")
+}
+
+@SuppressWarnings('UnusedPrivateMethod')
+private deleteDeviceTrait_Timer(deviceTrait) {
+    app.removeSetting("${deviceTrait.name}.maxTimerLimitSec")
+    app.removeSetting("${deviceTrait.name}.commandOnlyTimer")
+    app.removeSetting("${deviceTrait.name}.timerRemainingSecAttribute")
+    app.removeSetting("${deviceTrait.name}.timerPausedAttribute")
+    app.removeSetting("${deviceTrait.name}.timerStartCommand")
+    app.removeSetting("${deviceTrait.name}.timerAdjustCommand")
+    app.removeSetting("${deviceTrait.name}.timerCancelCommand")
+    app.removeSetting("${deviceTrait.name}.timerPauseCommand")
+    app.removeSetting("${deviceTrait.name}.timerResumeCommand")
+    app.removeSetting("${deviceTrait.name}.timerPausedValue")    
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -3492,12 +4070,10 @@ private static final GOOGLE_DEVICE_TRAITS = [
     CameraStream: "Camera Stream",
     //Channel: "Channel",
     ColorSetting: "Color Setting",
-    //ColorSpectrum: "Color Spectrum",
-    //ColorTemperature: "Color Temperature",
     //Cook: "Cook",
     //Dispense: "Dispense",
     Dock: "Dock",
-    //EnergyStorage: "Energy Storage",
+    EnergyStorage: "Energy Storage",
     FanSpeed: "Fan Speed",
     //Fill: "Fill",
     HumiditySetting: "Humidity Setting",
@@ -3505,23 +4081,23 @@ private static final GOOGLE_DEVICE_TRAITS = [
     //LightEffects: "Light Effects",
     Locator: "Locator",
     LockUnlock: "Lock/Unlock",
-    //MediaState: "Media State",
+    MediaState: "Media State",
     //Modes: "Modes",
     //NetworkControl: "Network Control",
     //ObjectDetection: "Object Detection",
     OnOff: "On/Off",
     OpenClose: "Open/Close",
-    //Reboot: "Reboot",
+    Reboot: "Reboot",
     Rotation: "Rotation",
     //RunCycle: "Run Cycle",
     //SensorState: "Sensor State",
     Scene: "Scene",
-    //SoftwareUpdate: "Software Update",
+    SoftwareUpdate: "Software Update",
     StartStop: "Start/Stop",
     //StatusReport: "Status Report",
     TemperatureControl: "Temperature Control",
     TemperatureSetting: "Temperature Setting",
-    //Timer: "Timer",
+    Timer: "Timer",
     Toggles: "Toggles",
     //TransportControl: "Transport Control",
     Volume: "Volume",

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2443,7 +2443,7 @@ private deviceStateForTrait_Dock(deviceTrait, device) {
     ]
 }
 
-@SuppressWarnings(['UnusedPrivateMethod', 'MethodSize'])
+@SuppressWarnings(['UnusedPrivateMethod', 'LineLength'])
 private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
     def deviceState = [:]
     if (deviceTrait.descriptiveCapacityRemainingAttribute != null) {

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2447,7 +2447,8 @@ private deviceStateForTrait_Dock(deviceTrait, device) {
 private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
     def deviceState = [:]
     if (deviceTrait.descriptiveCapacityRemainingAttribute != null) {
-        deviceState.descriptiveCapacityRemaining = device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
+        deviceState.descriptiveCapacityRemaining =
+		    device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
     }
     deviceState.capacityRemaining = [
         [

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -578,7 +578,7 @@ private deviceTraitPreferences_Dock(deviceTrait) {
     }
 }
 
-@SuppressWarnings('UnusedPrivateMethod')
+@SuppressWarnings(['UnusedPrivateMethod', 'MethodSize'])
 private deviceTraitPreferences_EnergyStorage(deviceTrait) {
     googleEnergyStorageDistanceUnitForUX = [
         "KILOMETERS":      "Kilometers",
@@ -613,22 +613,14 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
                 name: "${deviceTrait.name}.chargeCommand",
                 title: "Charge Command",
                 type: "text",
-                defaultValue: "charge",
                 required: true
             )
         }
         input(
-            name: "${deviceTrait.name}.descriptiveCapacityRemainingAttribute",
-            title: "Descriptive Capacity Remaining",
-            type: "text",
-            defaultValue: "descriptiveCapacityRemaining",
-            required: true
-        )
-        input(
             name: "${deviceTrait.name}.capacityRemainingRawValue",
             title: "Capacity Remaining Value",
             type: "text",
-            defaultValue: "capacityRemainingRawValue",
+            defaultValue: "battery",
             required: true
         )
         input(
@@ -639,13 +631,11 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             multiple: false,
             required: true,
             submitOnChange: true
-        )
+        )        
         input(
             name: "${deviceTrait.name}.capacityUntilFullRawValue",
             title: "Capacity Until Full Value",
             type: "text",
-            defaultValue: "capacityUntilFullRawValue",
-            required: true
         )
         input(
             name: "${deviceTrait.name}.capacityUntilFullUnit",
@@ -653,36 +643,32 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             type: "enum",
             options: googleCapacityUnits,
             multiple: false,
-            required: true,
             submitOnChange: true
         )
+        input(
+            name: "${deviceTrait.name}.descriptiveCapacityRemainingAttribute",
+            title: "Descriptive Capacity Remaining",
+            type: "text",
+        )        
         input(
             name: "${deviceTrait.name}.isChargingAttribute",
             title: "Charging Attribute",
             type: "text",
-            defaultValue: "isCharging",
-            required: true
         )
         input(
             name: "${deviceTrait.name}.chargingValue",
             title: "Charging Value",
             type: "text",
-            defaultValue: "true",
-            required: true
         )
         input(
             name: "${deviceTrait.name}.isPluggedInAttribute",
-            title: "ve",
+            title: "Plugged in Attribute",
             type: "text",
-            defaultValue: "isPluggedIn",
-            required: true
         )
         input(
             name: "${deviceTrait.name}.pluggedInValue",
-            title: "Plugged In Value",
+            title: "Plugged in Value",
             type: "text",
-            defaultValue: "true",
-            required: true
         )
         if ((deviceTrait.capacityRemainingUnit == "MILES") || (deviceTrait.capacityRemainingUnit == "KILOMETERS")
             || (deviceTrait.capacityUntilFullUnit == "MILES") || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {
@@ -692,7 +678,6 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
                 type: "enum",
                 options: googleEnergyStorageDistanceUnitForUX,
                 multiple: false,
-                required: true,
                 submitOnChange: true
             )
         }
@@ -872,28 +857,33 @@ private deviceTraitPreferences_MediaState(deviceTrait) {
             type: "bool",
             defaultValue: false,
             required: true,
+            submitOnChange: true,
         )
+        if (deviceTrait.supportActivityState) {
+            input(
+                name: "${deviceTrait.name}.activityStateAttribute",
+                title: "Activity State Attribute",
+                type: "text",
+                required: true
+            )
+        }
         input(
             name: "${deviceTrait.name}.supportPlaybackState",
             title: "Support Playback State",
             type: "bool",
             defaultValue: false,
             required: true,
+            submitOnChange: true,
         )
-        input(
-            name: "${deviceTrait.name}.activityStateAttribute",
-            title: "Activity State Attribute",
-            type: "text",
-            defaultValue: "activityState",
-            required: true
-        )
-        input(
-            name: "${deviceTrait.name}.playbackStateAttribute",
-            title: "Playback State Attribute",
-            type: "text",
-            defaultValue: "playbackState",
-            required: true
-        )
+        if (deviceTrait.supportPlaybackState) {
+            input(
+                name: "${deviceTrait.name}.playbackStateAttribute",
+                title: "Playback State Attribute",
+                type: "text",
+                defaultValue: "status",
+                required: true
+            )
+        }
     }
 }
 
@@ -1057,7 +1047,6 @@ def deviceTraitPreferences_Reboot(deviceTrait) {
             name: "${deviceTrait.name}.rebootCommand",
             title: "Reboot Command",
             type: "text",
-            defaultValue: "reboot",
             required: true
         )
     }
@@ -1124,14 +1113,12 @@ def deviceTraitPreferences_SoftwareUpdate(deviceTrait) {
             name: "${deviceTrait.name}.lastSoftwareUpdateUnixTimestampSecAttribute",
             title: "Last Software Update Unix Timestamp in Seconds Attribute",
             type: "text",
-            defaultValue: "lastSoftwareUpdateUnixTimestamp",
             required: true
         )
         input(
             name: "${deviceTrait.name}.softwareUpdateCommand",
             title: "Software Update Command",
             type: "text",
-            defaultValue: "softwareUpdate",
             required: true
         )
     }

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2447,7 +2447,8 @@ private deviceStateForTrait_Dock(deviceTrait, device) {
 private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
     def deviceState = [:]
     if (deviceTrait.descriptiveCapacityRemainingAttribute != null) {
-        deviceState.descriptiveCapacityRemaining =  device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
+        deviceState.descriptiveCapacityRemaining 
+		    = device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
     }
     deviceState.capacityRemaining = [
         [
@@ -2456,19 +2457,20 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
         ]
     ]
     if (deviceTrait.isRechargeable) {
-        if (deviceTrait.capacityUntilFullRawValue != null) {    
+        if (deviceTrait.capacityUntilFullRawValue != null) {
             deviceState.capacityUntilFull = [
                 rawValue: device.currentValue(deviceTrait.capacityUntilFullRawValue).toInteger(),
                 unit:     deviceTrait.capacityUntilFullUnit,
             ]
         }
         if (deviceTrait.chargingValue != null) {
-           deviceState.isCharging = device.currentValue(deviceTrait.isChargingAttribute) == deviceTrait.chargingValue
-        } 
-        if (deviceTrait.pluggedInValue != null) {
-            deviceState.isPluggedIn = device.currentValue(deviceTrait.isPluggedInAttribute) == deviceTrait.pluggedInValue
+            deviceState.isCharging = device.currentValue(deviceTrait.isChargingAttribute) == deviceTrait.chargingValue
         }
-    } 
+        if (deviceTrait.pluggedInValue != null) {
+            deviceState.isPluggedIn 
+			    = device.currentValue(deviceTrait.isPluggedInAttribute) == deviceTrait.pluggedInValue
+        }
+    }
 
     return deviceState
 }

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2447,8 +2447,8 @@ private deviceStateForTrait_Dock(deviceTrait, device) {
 private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
     def deviceState = [:]
     if (deviceTrait.descriptiveCapacityRemainingAttribute != null) {
-        deviceState.descriptiveCapacityRemaining 
-		    = device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
+        deviceState.descriptiveCapacityRemaining
+            = device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
     }
     deviceState.capacityRemaining = [
         [
@@ -2467,8 +2467,8 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
             deviceState.isCharging = device.currentValue(deviceTrait.isChargingAttribute) == deviceTrait.chargingValue
         }
         if (deviceTrait.pluggedInValue != null) {
-            deviceState.isPluggedIn 
-			    = device.currentValue(deviceTrait.isPluggedInAttribute) == deviceTrait.pluggedInValue
+            deviceState.isPluggedIn
+                = device.currentValue(deviceTrait.isPluggedInAttribute) == deviceTrait.pluggedInValue
         }
     }
 

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -591,7 +591,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
         "PERCENTAGE":      "Percentage",
         "KILOWATT_HOURS":  "Kilowatt Hours",
     ]
-    section("Energy Storage Settings") {          
+    section("Energy Storage Settings") {
         input(
             name: "${deviceTrait.name}.isRechargeable",
             title: "Rechargeable",
@@ -616,17 +616,17 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             multiple: false,
             required: true,
             submitOnChange: true
-        )      
+        )
         input(
             name: "${deviceTrait.name}.advancedEnergySettings",
             title: "Enable Advanced Settings",
             type: "bool",
             defaultValue: false,
             submitOnChange: true
-        )          
+        )
     }
-    if (deviceTrait.advancedEnergySettings) {    
-        section("Advanced Settings") {      
+    if (deviceTrait.advancedEnergySettings) {
+        section("Advanced Settings") {
             input(
                 name: "${deviceTrait.name}.queryOnlyEnergyStorage",
                 title: "Query Only Energy Storage",
@@ -642,7 +642,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
                     type: "text",
                     required: true
                 )
-            }        
+            }
             input(
                 name: "${deviceTrait.name}.capacityUntilFullRawValue",
                 title: "Capacity Until Full Value",
@@ -660,7 +660,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
                 name: "${deviceTrait.name}.descriptiveCapacityRemainingAttribute",
                 title: "Descriptive Capacity Remaining",
                 type: "text",
-            )        
+            )
             input(
                 name: "${deviceTrait.name}.isChargingAttribute",
                 title: "Charging Attribute",
@@ -681,8 +681,10 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
                 title: "Plugged in Value",
                 type: "text",
             )
-            if ((deviceTrait.capacityRemainingUnit == "MILES") || (deviceTrait.capacityRemainingUnit == "KILOMETERS")
-                || (deviceTrait.capacityUntilFullUnit == "MILES") || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {               
+            if ((deviceTrait.capacityRemainingUnit == "MILES") 
+			    || (deviceTrait.capacityRemainingUnit == "KILOMETERS")
+                || (deviceTrait.capacityUntilFullUnit == "MILES") 
+				|| (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {
                 input(
                     name: "${deviceTrait.name}.energyStorageDistanceUnitForUX",
                     title: "Supported Distance Units",
@@ -692,7 +694,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
                     submitOnChange: true
                 )
             }
-        }  
+        }
     }
 }
 
@@ -2452,7 +2454,7 @@ private deviceStateForTrait_Dock(deviceTrait, device) {
 
 @SuppressWarnings('UnusedPrivateMethod')
 private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
-    def deviceState = [:]    
+    def deviceState = [:]
     descriptiveCapacityRemaining = device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
     if (descriptiveCapacityRemaining == null) {
         descriptiveCapacityRemaining = "HIGH"
@@ -2465,7 +2467,7 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
         ]
     ]
     capacityUntilFullRawValue = device.currentValue(deviceTrait.capacityUntilFullRawValue).toInteger()
-    capacityUntilFullUnit     = deviceTrait.capacityUntilFullUnit    
+    capacityUntilFullUnit     = deviceTrait.capacityUntilFullUnit
     if ((capacityUntilFullRawValue == null) || (capacityUntilFullUnit == null)) {
         capacityUntilFullRawValue = 0
         capacityUntilFullUnit = "PERCENTAGE"
@@ -2475,7 +2477,7 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
             rawValue: capacityUntilFullRawValue,
             unit:     capacityUntilFullUnit,
         ]
-    ]    
+    ]
     if (deviceTrait.chargingValue != null) {
         deviceState.isCharging = device.currentValue(deviceTrait.isChargingAttribute) == deviceTrait.chargingValue
     } else {
@@ -2486,7 +2488,7 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
     } else {
         deviceState.isPluggedIn = false
     }
-    
+
     return deviceState
 }
 

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -617,83 +617,74 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             required: true,
             submitOnChange: true
         )
+    }
+    section(hidable: true, hidden: true, "Advanced Settings") {
         input(
-            name: "${deviceTrait.name}.advancedEnergySettings",
-            title: "Enable Advanced Settings",
+            name: "${deviceTrait.name}.queryOnlyEnergyStorage",
+            title: "Query Only Energy Storage",
             type: "bool",
-            defaultValue: false,
+            defaultValue: true,
+            required: true,
             submitOnChange: true
         )
-    }
-    if (deviceTrait.advancedEnergySettings) {
-        section("Advanced Settings") {
+        if (!deviceTrait.queryOnlyEnergyStorage) {
             input(
-                name: "${deviceTrait.name}.queryOnlyEnergyStorage",
-                title: "Query Only Energy Storage",
-                type: "bool",
-                defaultValue: true,
-                required: true,
-                submitOnChange: true
-            )
-            if (!deviceTrait.queryOnlyEnergyStorage) {
-                input(
-                    name: "${deviceTrait.name}.chargeCommand",
-                    title: "Charge Command",
-                    type: "text",
-                    required: true
-                )
-            }
-            input(
-                name: "${deviceTrait.name}.capacityUntilFullRawValue",
-                title: "Capacity Until Full Value",
+                name: "${deviceTrait.name}.chargeCommand",
+                title: "Charge Command",
                 type: "text",
+                required: true
             )
+        }
+        input(
+            name: "${deviceTrait.name}.capacityUntilFullRawValue",
+            title: "Capacity Until Full Value",
+            type: "text",
+        )
+        input(
+            name: "${deviceTrait.name}.capacityUntilFullUnit",
+            title: "Capacity Until Full Unit",
+            type: "enum",
+            options: googleCapacityUnits,
+            multiple: false,
+            submitOnChange: true
+        )
+        input(
+            name: "${deviceTrait.name}.descriptiveCapacityRemainingAttribute",
+            title: "Descriptive Capacity Remaining",
+            type: "text",
+        )
+        input(
+            name: "${deviceTrait.name}.isChargingAttribute",
+            title: "Charging Attribute",
+            type: "text",
+        )
+        input(
+            name: "${deviceTrait.name}.chargingValue",
+            title: "Charging Value",
+            type: "text",
+        )
+        input(
+            name: "${deviceTrait.name}.isPluggedInAttribute",
+            title: "Plugged in Attribute",
+            type: "text",
+        )
+        input(
+            name: "${deviceTrait.name}.pluggedInValue",
+            title: "Plugged in Value",
+            type: "text",
+        )
+        if ((deviceTrait.capacityRemainingUnit == "MILES")
+            || (deviceTrait.capacityRemainingUnit == "KILOMETERS")
+            || (deviceTrait.capacityUntilFullUnit == "MILES")
+            || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {
             input(
-                name: "${deviceTrait.name}.capacityUntilFullUnit",
-                title: "Capacity Until Full Unit",
+                name: "${deviceTrait.name}.energyStorageDistanceUnitForUX",
+                title: "Supported Distance Units",
                 type: "enum",
-                options: googleCapacityUnits,
+                options: googleEnergyStorageDistanceUnitForUX,
                 multiple: false,
                 submitOnChange: true
             )
-            input(
-                name: "${deviceTrait.name}.descriptiveCapacityRemainingAttribute",
-                title: "Descriptive Capacity Remaining",
-                type: "text",
-            )
-            input(
-                name: "${deviceTrait.name}.isChargingAttribute",
-                title: "Charging Attribute",
-                type: "text",
-            )
-            input(
-                name: "${deviceTrait.name}.chargingValue",
-                title: "Charging Value",
-                type: "text",
-            )
-            input(
-                name: "${deviceTrait.name}.isPluggedInAttribute",
-                title: "Plugged in Attribute",
-                type: "text",
-            )
-            input(
-                name: "${deviceTrait.name}.pluggedInValue",
-                title: "Plugged in Value",
-                type: "text",
-            )
-            if ((deviceTrait.capacityRemainingUnit == "MILES")
-                || (deviceTrait.capacityRemainingUnit == "KILOMETERS")
-                || (deviceTrait.capacityUntilFullUnit == "MILES")
-                || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {
-                input(
-                    name: "${deviceTrait.name}.energyStorageDistanceUnitForUX",
-                    title: "Supported Distance Units",
-                    type: "enum",
-                    options: googleEnergyStorageDistanceUnitForUX,
-                    multiple: false,
-                    submitOnChange: true
-                )
-            }
         }
     }
 }
@@ -3069,7 +3060,6 @@ private traitFromSettings_EnergyStorage(traitName) {
         isPluggedInAttribute:                     settings."${traitName}.isPluggedInAttribute",
         pluggedInValue:                           settings."${traitName}.pluggedInValue",
         chargeCommand:                            settings."${traitName}.chargeCommand",
-        advancedEnergySettings:                   settings."${traitName}.advancedEnergySettings",
         commands:                                 []
     ]
     if (!energyStorageTrait.queryOnlyEnergyStorage) {
@@ -3552,7 +3542,6 @@ private deleteDeviceTrait_Dock(deviceTrait) {
 
 @SuppressWarnings('UnusedPrivateMethod')
 private deleteDeviceTrait_EnergyStorage(deviceTrait) {
-    app.removeSetting("${deviceTrait.name}.advancedEnergySettings")
     app.removeSetting("${deviceTrait.name}.energyStorageDistanceUnitForUX")
     app.removeSetting("${deviceTrait.name}.isRechargeable")
     app.removeSetting("${deviceTrait.name}.queryOnlyEnergyStorage")

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -631,7 +631,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             multiple: false,
             required: true,
             submitOnChange: true
-        )        
+        )
         input(
             name: "${deviceTrait.name}.capacityUntilFullRawValue",
             title: "Capacity Until Full Value",
@@ -649,7 +649,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             name: "${deviceTrait.name}.descriptiveCapacityRemainingAttribute",
             title: "Descriptive Capacity Remaining",
             type: "text",
-        )        
+        )
         input(
             name: "${deviceTrait.name}.isChargingAttribute",
             title: "Charging Attribute",

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -681,10 +681,10 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
                 title: "Plugged in Value",
                 type: "text",
             )
-            if ((deviceTrait.capacityRemainingUnit == "MILES") 
-			    || (deviceTrait.capacityRemainingUnit == "KILOMETERS")
-                || (deviceTrait.capacityUntilFullUnit == "MILES") 
-				|| (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {
+            if ((deviceTrait.capacityRemainingUnit == "MILES")
+                || (deviceTrait.capacityRemainingUnit == "KILOMETERS")
+                || (deviceTrait.capacityUntilFullUnit == "MILES")
+                || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {
                 input(
                     name: "${deviceTrait.name}.energyStorageDistanceUnitForUX",
                     title: "Supported Distance Units",

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -684,7 +684,8 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             defaultValue: "true",
             required: true
         )
-        if ((deviceTrait.capacityRemainingUnit == "MILES") || (deviceTrait.capacityRemainingUnit == "KILOMETERS") || (deviceTrait.capacityUntilFullUnit == "MILES") || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {
+        if ((deviceTrait.capacityRemainingUnit == "MILES") || (deviceTrait.capacityRemainingUnit == "KILOMETERS") 
+		    || (deviceTrait.capacityUntilFullUnit == "MILES") || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {
             input(
                 name: "${deviceTrait.name}.energyStorageDistanceUnitForUX",
                 title: "Supported Distance Units",
@@ -2273,7 +2274,7 @@ private executeCommand_TimerAdjust(deviceInfo, command) {
     deviceInfo.device."${timerTrait.timerAdjustCommand}"()
     def retVal = [:]
     if (!deviceTrait.commandOnlyTimer) {
-        retVal= [
+        retVal = [
             timerTimeSec: device.currentValue(timerTrait.timerRemainingSecAttribute)
         ]
     }
@@ -2311,7 +2312,7 @@ private executeCommand_TimerStart(deviceInfo, command) {
     deviceInfo.device."${timerTrait.timerStartCommand}"()
     def retVal = [:]
     if (!deviceTrait.commandOnlyTimer) {
-        retVal= [
+        retVal = [
             timerTimeSec: device.currentValue(timerTrait.timerRemainingSecAttribute)
         ]
     }
@@ -2566,7 +2567,8 @@ private deviceStateForTrait_Scene(deviceTrait, device) {
 @SuppressWarnings(['UnusedPrivateMethod', 'UnusedPrivateMethodParameter'])
 private deviceStateForTrait_SoftwareUpdate(deviceTrait, device) {
     return [
-        lastSoftwareUpdateUnixTimestampSec: device.currentValue(deviceTrait.lastSoftwareUpdateUnixTimestampSecAttribute).toInteger()
+        lastSoftwareUpdateUnixTimestampSec: 
+		        device.currentValue(deviceTrait.lastSoftwareUpdateUnixTimestampSecAttribute).toInteger()
     ]
 }
 
@@ -2654,7 +2656,7 @@ private deviceStateForTrait_Timer(deviceTrait, device) {
         // report no running timers
         deviceState = [
             timerRemainingSec: -1
-        ]	
+        ]
     } else {
         deviceState = [
             timerRemainingSec: device.currentValue(deviceTrait.timerRemainingSecAttribute),
@@ -3220,7 +3222,8 @@ private traitFromSettings_Scene(traitName) {
 @SuppressWarnings('UnusedPrivateMethod')
 private traitFromSettings_SoftwareUpdate(traitName) {
     return [
-        lastSoftwareUpdateUnixTimestampSecAttribute:    settings."${traitName}.lastSoftwareUpdateUnixTimestampSecAttribute",
+        lastSoftwareUpdateUnixTimestampSecAttribute:
+		                          settings."${traitName}.lastSoftwareUpdateUnixTimestampSecAttribute",
         softwareUpdateCommand:                          settings."${traitName}.softwareUpdateCommand",
         commands:                                       ["Software Update"]
     ]

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -684,8 +684,8 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             defaultValue: "true",
             required: true
         )
-        if ((deviceTrait.capacityRemainingUnit == "MILES") || (deviceTrait.capacityRemainingUnit == "KILOMETERS") 
-		    || (deviceTrait.capacityUntilFullUnit == "MILES") || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {
+        if ((deviceTrait.capacityRemainingUnit == "MILES") || (deviceTrait.capacityRemainingUnit == "KILOMETERS")
+            || (deviceTrait.capacityUntilFullUnit == "MILES") || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {
             input(
                 name: "${deviceTrait.name}.energyStorageDistanceUnitForUX",
                 title: "Supported Distance Units",
@@ -2567,8 +2567,8 @@ private deviceStateForTrait_Scene(deviceTrait, device) {
 @SuppressWarnings(['UnusedPrivateMethod', 'UnusedPrivateMethodParameter'])
 private deviceStateForTrait_SoftwareUpdate(deviceTrait, device) {
     return [
-        lastSoftwareUpdateUnixTimestampSec: 
-		        device.currentValue(deviceTrait.lastSoftwareUpdateUnixTimestampSecAttribute).toInteger()
+        lastSoftwareUpdateUnixTimestampSec:
+            device.currentValue(deviceTrait.lastSoftwareUpdateUnixTimestampSecAttribute).toInteger()
     ]
 }
 
@@ -3223,7 +3223,7 @@ private traitFromSettings_Scene(traitName) {
 private traitFromSettings_SoftwareUpdate(traitName) {
     return [
         lastSoftwareUpdateUnixTimestampSecAttribute:
-		                          settings."${traitName}.lastSoftwareUpdateUnixTimestampSecAttribute",
+                                  settings."${traitName}.lastSoftwareUpdateUnixTimestampSecAttribute",
         softwareUpdateCommand:                          settings."${traitName}.softwareUpdateCommand",
         commands:                                       ["Software Update"]
     ]

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2443,7 +2443,7 @@ private deviceStateForTrait_Dock(deviceTrait, device) {
     ]
 }
 
-@SuppressWarnings('UnusedPrivateMethod')
+@SuppressWarnings(['UnusedPrivateMethod', 'MethodSize'])
 private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
     def deviceState = [:]
     if (deviceTrait.descriptiveCapacityRemainingAttribute != null) {

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -591,7 +591,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
         "PERCENTAGE":      "Percentage",
         "KILOWATT_HOURS":  "Kilowatt Hours",
     ]
-    section("Energy Storage Settings") {
+    section("Energy Storage Settings") {          
         input(
             name: "${deviceTrait.name}.isRechargeable",
             title: "Rechargeable",
@@ -600,22 +600,6 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             required: true,
             submitOnChange: true
         )
-        input(
-            name: "${deviceTrait.name}.queryOnlyEnergyStorage",
-            title: "Query Only Energy Storage",
-            type: "bool",
-            defaultValue: true,
-            required: true,
-            submitOnChange: true
-        )
-        if (!deviceTrait.queryOnlyEnergyStorage) {
-            input(
-                name: "${deviceTrait.name}.chargeCommand",
-                title: "Charge Command",
-                type: "text",
-                required: true
-            )
-        }
         input(
             name: "${deviceTrait.name}.capacityRemainingRawValue",
             title: "Capacity Remaining Value",
@@ -632,58 +616,83 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             multiple: false,
             required: true,
             submitOnChange: true
-        )
+        )      
         input(
-            name: "${deviceTrait.name}.capacityUntilFullRawValue",
-            title: "Capacity Until Full Value",
-            type: "text",
-        )
-        input(
-            name: "${deviceTrait.name}.capacityUntilFullUnit",
-            title: "Capacity Until Full Unit",
-            type: "enum",
-            options: googleCapacityUnits,
-            multiple: false,
+            name: "${deviceTrait.name}.advancedEnergySettings",
+            title: "Enable Advanced Settings",
+            type: "bool",
+            defaultValue: false,
             submitOnChange: true
-        )
-        input(
-            name: "${deviceTrait.name}.descriptiveCapacityRemainingAttribute",
-            title: "Descriptive Capacity Remaining",
-            type: "text",
-        )
-        input(
-            name: "${deviceTrait.name}.isChargingAttribute",
-            title: "Charging Attribute",
-            type: "text",
-        )
-        input(
-            name: "${deviceTrait.name}.chargingValue",
-            title: "Charging Value",
-            type: "text",
-        )
-        input(
-            name: "${deviceTrait.name}.isPluggedInAttribute",
-            title: "Plugged in Attribute",
-            type: "text",
-        )
-        input(
-            name: "${deviceTrait.name}.pluggedInValue",
-            title: "Plugged in Value",
-            type: "text",
-        )
+        )          
     }
-    if ((deviceTrait.capacityRemainingUnit == "MILES") || (deviceTrait.capacityRemainingUnit == "KILOMETERS")
-        || (deviceTrait.capacityUntilFullUnit == "MILES") || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {
-        section("Advanced Settings") {
+    if (deviceTrait.advancedEnergySettings) {    
+        section("Advanced Settings") {      
             input(
-                name: "${deviceTrait.name}.energyStorageDistanceUnitForUX",
-                title: "Supported Distance Units",
+                name: "${deviceTrait.name}.queryOnlyEnergyStorage",
+                title: "Query Only Energy Storage",
+                type: "bool",
+                defaultValue: true,
+                required: true,
+                submitOnChange: true
+            )
+            if (!deviceTrait.queryOnlyEnergyStorage) {
+                input(
+                    name: "${deviceTrait.name}.chargeCommand",
+                    title: "Charge Command",
+                    type: "text",
+                    required: true
+                )
+            }        
+            input(
+                name: "${deviceTrait.name}.capacityUntilFullRawValue",
+                title: "Capacity Until Full Value",
+                type: "text",
+            )
+            input(
+                name: "${deviceTrait.name}.capacityUntilFullUnit",
+                title: "Capacity Until Full Unit",
                 type: "enum",
-                options: googleEnergyStorageDistanceUnitForUX,
+                options: googleCapacityUnits,
                 multiple: false,
                 submitOnChange: true
             )
-        }
+            input(
+                name: "${deviceTrait.name}.descriptiveCapacityRemainingAttribute",
+                title: "Descriptive Capacity Remaining",
+                type: "text",
+            )        
+            input(
+                name: "${deviceTrait.name}.isChargingAttribute",
+                title: "Charging Attribute",
+                type: "text",
+            )
+            input(
+                name: "${deviceTrait.name}.chargingValue",
+                title: "Charging Value",
+                type: "text",
+            )
+            input(
+                name: "${deviceTrait.name}.isPluggedInAttribute",
+                title: "Plugged in Attribute",
+                type: "text",
+            )
+            input(
+                name: "${deviceTrait.name}.pluggedInValue",
+                title: "Plugged in Value",
+                type: "text",
+            )
+            if ((deviceTrait.capacityRemainingUnit == "MILES") || (deviceTrait.capacityRemainingUnit == "KILOMETERS")
+                || (deviceTrait.capacityUntilFullUnit == "MILES") || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {               
+                input(
+                    name: "${deviceTrait.name}.energyStorageDistanceUnitForUX",
+                    title: "Supported Distance Units",
+                    type: "enum",
+                    options: googleEnergyStorageDistanceUnitForUX,
+                    multiple: false,
+                    submitOnChange: true
+                )
+            }
+        }  
     }
 }
 
@@ -2443,7 +2452,7 @@ private deviceStateForTrait_Dock(deviceTrait, device) {
 
 @SuppressWarnings('UnusedPrivateMethod')
 private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
-    def deviceState = [:]
+    def deviceState = [:]    
     descriptiveCapacityRemaining = device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
     if (descriptiveCapacityRemaining == null) {
         descriptiveCapacityRemaining = "HIGH"
@@ -2456,7 +2465,7 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
         ]
     ]
     capacityUntilFullRawValue = device.currentValue(deviceTrait.capacityUntilFullRawValue).toInteger()
-    capacityUntilFullUnit     = deviceTrait.capacityUntilFullUnit
+    capacityUntilFullUnit     = deviceTrait.capacityUntilFullUnit    
     if ((capacityUntilFullRawValue == null) || (capacityUntilFullUnit == null)) {
         capacityUntilFullRawValue = 0
         capacityUntilFullUnit = "PERCENTAGE"
@@ -2466,7 +2475,7 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
             rawValue: capacityUntilFullRawValue,
             unit:     capacityUntilFullUnit,
         ]
-    ]
+    ]    
     if (deviceTrait.chargingValue != null) {
         deviceState.isCharging = device.currentValue(deviceTrait.isChargingAttribute) == deviceTrait.chargingValue
     } else {
@@ -2477,7 +2486,7 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
     } else {
         deviceState.isPluggedIn = false
     }
-
+    
     return deviceState
 }
 
@@ -3058,6 +3067,7 @@ private traitFromSettings_EnergyStorage(traitName) {
         isPluggedInAttribute:                     settings."${traitName}.isPluggedInAttribute",
         pluggedInValue:                           settings."${traitName}.pluggedInValue",
         chargeCommand:                            settings."${traitName}.chargeCommand",
+        advancedEnergySettings:                   settings."${traitName}.advancedEnergySettings",
         commands:                                 []
     ]
     if (!energyStorageTrait.queryOnlyEnergyStorage) {
@@ -3540,6 +3550,7 @@ private deleteDeviceTrait_Dock(deviceTrait) {
 
 @SuppressWarnings('UnusedPrivateMethod')
 private deleteDeviceTrait_EnergyStorage(deviceTrait) {
+    app.removeSetting("${deviceTrait.name}.advancedEnergySettings")
     app.removeSetting("${deviceTrait.name}.energyStorageDistanceUnitForUX")
     app.removeSetting("${deviceTrait.name}.isRechargeable")
     app.removeSetting("${deviceTrait.name}.queryOnlyEnergyStorage")

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -50,7 +50,6 @@
 //   * Apr 23 2021 - Added Energy Storage, Software Update, Reboot, Media State (query untested) and
 //                   Timer (commands untested) Traits.  Added missing camera trait protocol attributes.
 
-
 import groovy.json.JsonException
 import groovy.json.JsonOutput
 import groovy.transform.Field
@@ -2270,8 +2269,8 @@ private executeCommand_ThermostatSetMode(deviceInfo, command) {
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_TimerAdjust(deviceInfo, command) {
     checkMfa(deviceInfo.deviceType, "TimerAdjust", command)
-    def TimerTrait = deviceInfo.deviceType.traits.Timer
-    deviceInfo.device."${TimerTrait.timerAdjustCommand}"()
+    def timerTrait = deviceInfo.deviceType.traits.Timer
+    deviceInfo.device."${timerTrait.timerAdjustCommand}"()
     def retVal = [:]
     if (!deviceTrait.commandOnlyTimer) {
         retVal= [
@@ -2284,32 +2283,32 @@ private executeCommand_TimerAdjust(deviceInfo, command) {
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_TimerCancel(deviceInfo, command) {
     checkMfa(deviceInfo.deviceType, "TimerCancel", command)
-    def TimerTrait = deviceInfo.deviceType.traits.Timer
-    deviceInfo.device."${TimerTrait.timerCancelCommand}"()
+    def timerTrait = deviceInfo.deviceType.traits.Timer
+    deviceInfo.device."${timerTrait.timerCancelCommand}"()
     return [:]
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_TimerPause(deviceInfo, command) {
     checkMfa(deviceInfo.deviceType, "TimerPause", command)
-    def TimerTrait = deviceInfo.deviceType.traits.Timer
-    deviceInfo.device."${TimerTrait.timerPauseCommand}"()
+    def timerTrait = deviceInfo.deviceType.traits.Timer
+    deviceInfo.device."${timerTrait.timerPauseCommand}"()
     return [:]
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_TimerResume(deviceInfo, command) {
     checkMfa(deviceInfo.deviceType, "TimerResume", command)
-    def TimerTrait = deviceInfo.deviceType.traits.Timer
-    deviceInfo.device."${TimerTrait.timerResumeCommand}"()
+    def timerTrait = deviceInfo.deviceType.traits.Timer
+    deviceInfo.device."${timerTrait.timerResumeCommand}"()
     return [:]
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_TimerStart(deviceInfo, command) {
     checkMfa(deviceInfo.deviceType, "TimerStart", command)
-    def TimerTrait = deviceInfo.deviceType.traits.Timer
-    deviceInfo.device."${TimerTrait.timerStartCommand}"()
+    def timerTrait = deviceInfo.deviceType.traits.Timer
+    deviceInfo.device."${timerTrait.timerStartCommand}"()
     def retVal = [:]
     if (!deviceTrait.commandOnlyTimer) {
         retVal= [
@@ -2651,15 +2650,15 @@ private deviceStateForTrait_TemperatureSetting(deviceTrait, device) {
 @SuppressWarnings('UnusedPrivateMethod')
 private deviceStateForTrait_Timer(deviceTrait, device) {
     def deviceState = [:]
-    if (!deviceTrait.commandOnlyTimer) {
-        deviceState = [
-            timerRemainingSec: device.currentValue(deviceTrait.timerRemainingSecAttribute),
-            timerPaused: device.currentValue(deviceTrait.timerPausedAttribute) == deviceTrait.timerPausedValue
-        ]
-    } else {
+    if (deviceTrait.commandOnlyTimer) {
         // report no running timers
         deviceState = [
             timerRemainingSec: -1
+        ]	
+    } else {
+        deviceState = [
+            timerRemainingSec: device.currentValue(deviceTrait.timerRemainingSecAttribute),
+            timerPaused: device.currentValue(deviceTrait.timerPausedAttribute) == deviceTrait.timerPausedValue
         ]
     }
     return deviceState
@@ -3381,7 +3380,7 @@ private traitFromSettings_Timer(traitName) {
         maxTimerLimitSec:                 settings."${traitName}.maxTimerLimitSec",
         commandOnlyTimer:                 settings."${traitName}.commandOnlyTimer",
 
-        commands:                         ["Start","Adjust","Cancel","Pause","Resume"]
+        commands:                         ["Start", "Adjust", "Cancel", "Pause", "Resume"]
     ]
     if (!timerTrait.commandOnlyTimer) {
         timerTrait << [

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -632,7 +632,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             multiple: false,
             required: true,
             submitOnChange: true
-        )        
+        )
         input(
             name: "${deviceTrait.name}.capacityUntilFullRawValue",
             title: "Capacity Until Full Value",
@@ -650,7 +650,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             name: "${deviceTrait.name}.descriptiveCapacityRemainingAttribute",
             title: "Descriptive Capacity Remaining",
             type: "text",
-        )        
+        )
         input(
             name: "${deviceTrait.name}.isChargingAttribute",
             title: "Charging Attribute",
@@ -683,7 +683,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
                 multiple: false,
                 submitOnChange: true
             )
-        }    
+        }
     }
 }
 

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2448,7 +2448,7 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
     def deviceState = [:]
     if (deviceTrait.descriptiveCapacityRemainingAttribute != null) {
         deviceState.descriptiveCapacityRemaining =
-		    device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
+            device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
     }
     deviceState.capacityRemaining = [
         [

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -673,7 +673,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
         )
     }
     if ((deviceTrait.capacityRemainingUnit == "MILES") || (deviceTrait.capacityRemainingUnit == "KILOMETERS")
-        || (deviceTrait.capacityUntilFullUnit == "MILES") || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {    
+        || (deviceTrait.capacityUntilFullUnit == "MILES") || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {
         section("Advanced Settings") {
             input(
                 name: "${deviceTrait.name}.energyStorageDistanceUnitForUX",
@@ -2443,7 +2443,7 @@ private deviceStateForTrait_Dock(deviceTrait, device) {
 
 @SuppressWarnings('UnusedPrivateMethod')
 private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
-    def deviceState = [:]    
+    def deviceState = [:]
     descriptiveCapacityRemaining = device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
     if (descriptiveCapacityRemaining == null) {
         descriptiveCapacityRemaining = "HIGH"
@@ -2456,7 +2456,7 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
         ]
     ]
     capacityUntilFullRawValue = device.currentValue(deviceTrait.capacityUntilFullRawValue).toInteger()
-    capacityUntilFullUnit     = deviceTrait.capacityUntilFullUnit    
+    capacityUntilFullUnit     = deviceTrait.capacityUntilFullUnit
     if ((capacityUntilFullRawValue == null) || (capacityUntilFullUnit == null)) {
         capacityUntilFullRawValue = 0
         capacityUntilFullUnit = "PERCENTAGE"
@@ -2466,7 +2466,7 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
             rawValue: capacityUntilFullRawValue,
             unit:     capacityUntilFullUnit,
         ]
-    ]    
+    ]
     if (deviceTrait.chargingValue != null) {
         deviceState.isCharging = device.currentValue(deviceTrait.isChargingAttribute) == deviceTrait.chargingValue
     } else {
@@ -2477,7 +2477,7 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
     } else {
         deviceState.isPluggedIn = false
     }
-    
+
     return deviceState
 }
 

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -627,7 +627,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             required: true,
             submitOnChange: true
         )
-        if (!deviceTrait.queryOnlyEnergyStorage) {
+        if (deviceTrait.queryOnlyEnergyStorage == false) {
             input(
                 name: "${deviceTrait.name}.chargeCommand",
                 title: "Charge Command",
@@ -1471,7 +1471,7 @@ private deviceTraitPreferences_Timer(deviceTrait) {
             required: true,
             defaultValue: "86400"
         )
-        if (!deviceTrait.commandOnlyTimer) {
+        if (deviceTrait.commandOnlyTimer == false) {
             input(
                 name: "${deviceTrait.name}.timerRemainingSecAttribute",
                 title: "Time Remaining Attribute",
@@ -2446,39 +2446,29 @@ private deviceStateForTrait_Dock(deviceTrait, device) {
 @SuppressWarnings('UnusedPrivateMethod')
 private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
     def deviceState = [:]
-    descriptiveCapacityRemaining = device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
-    if (descriptiveCapacityRemaining == null) {
-        descriptiveCapacityRemaining = "HIGH"
+    if (deviceTrait.descriptiveCapacityRemainingAttribute != null) {
+        deviceState.descriptiveCapacityRemaining =  device.currentValue(deviceTrait.descriptiveCapacityRemainingAttribute)
     }
-    deviceState.descriptiveCapacityRemaining =  descriptiveCapacityRemaining
     deviceState.capacityRemaining = [
         [
             rawValue: device.currentValue(deviceTrait.capacityRemainingRawValue).toInteger(),
             unit:     deviceTrait.capacityRemainingUnit,
         ]
     ]
-    capacityUntilFullRawValue = device.currentValue(deviceTrait.capacityUntilFullRawValue).toInteger()
-    capacityUntilFullUnit     = deviceTrait.capacityUntilFullUnit
-    if ((capacityUntilFullRawValue == null) || (capacityUntilFullUnit == null)) {
-        capacityUntilFullRawValue = 0
-        capacityUntilFullUnit = "PERCENTAGE"
-    }
-    deviceState.capacityUntilFull = [
-        [
-            rawValue: capacityUntilFullRawValue,
-            unit:     capacityUntilFullUnit,
-        ]
-    ]
-    if (deviceTrait.chargingValue != null) {
-        deviceState.isCharging = device.currentValue(deviceTrait.isChargingAttribute) == deviceTrait.chargingValue
-    } else {
-        deviceState.isCharging = false
-    }
-    if (deviceTrait.pluggedInValue != null) {
-        deviceState.isPluggedIn = device.currentValue(deviceTrait.isPluggedInAttribute) == deviceTrait.pluggedInValue
-    } else {
-        deviceState.isPluggedIn = false
-    }
+    if (deviceTrait.isRechargeable) {
+        if (deviceTrait.capacityUntilFullRawValue != null) {    
+            deviceState.capacityUntilFull = [
+                rawValue: device.currentValue(deviceTrait.capacityUntilFullRawValue).toInteger(),
+                unit:     deviceTrait.capacityUntilFullUnit,
+            ]
+        }
+        if (deviceTrait.chargingValue != null) {
+           deviceState.isCharging = device.currentValue(deviceTrait.isChargingAttribute) == deviceTrait.chargingValue
+        } 
+        if (deviceTrait.pluggedInValue != null) {
+            deviceState.isPluggedIn = device.currentValue(deviceTrait.isPluggedInAttribute) == deviceTrait.pluggedInValue
+        }
+    } 
 
     return deviceState
 }

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -47,7 +47,7 @@
 //   * Jan 31 2021 - Don't break the whole app if someone creates an invalid toggle
 //   * Feb 28 2021 - Add new device types supported by Google
 //   * Apr 18 2021 - Added Locator Trait
-//   * Apr 23 2021 - Added Energy Storage, Software Update, Reboot, Media State (query untested) and 
+//   * Apr 23 2021 - Added Energy Storage, Software Update, Reboot, Media State (query untested) and
 //                   Timer (commands untested) Traits.  Added missing camera trait protocol attributes.
 
 
@@ -426,10 +426,10 @@ private deviceTraitPreferences_Brightness(deviceTrait) {
 def deviceTraitPreferences_CameraStream(deviceTrait) {
     googleCameraStreamSupportedProtocols = [
         "progressive_mp4":         "Progressive MP4",
-        "hls":                     "HLS",        
+        "hls":                     "HLS",
         "dash":                    "Dash",
-        "smooth_stream":           "Smooth Stream",      
-    ]          
+        "smooth_stream":           "Smooth Stream",
+    ]
     section("Stream Camera") {
         input(
             name: "${deviceTrait.name}.cameraStreamAttribute",
@@ -445,7 +445,7 @@ def deviceTraitPreferences_CameraStream(deviceTrait) {
             options: googleCameraStreamSupportedProtocols,
             multiple: true,
             required: true,
-        )                         
+        )
     }
 }
 
@@ -584,21 +584,21 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
     googleEnergyStorageDistanceUnitForUX = [
         "KILOMETERS":      "Kilometers",
         "MILES":           "Miles",
-    ]     
+    ]
     googleCapacityUnits = [
         "SECONDS":         "Seconds",
-        "MILES":           "Miles",        
+        "MILES":           "Miles",
         "KILOMETERS":      "Kilometers",
         "PERCENTAGE":      "Percentage",
-        "KILOWATT_HOURS":  "Kilowatt Hours",        
-    ]      
+        "KILOWATT_HOURS":  "Kilowatt Hours",
+    ]
     section("Energy Storage Settings") {
         input(
             name: "${deviceTrait.name}.isRechargeable",
             title: "Rechargeable",
             type: "bool",
             defaultValue: false,
-            required: true,            
+            required: true,
             submitOnChange: true
         )
         input(
@@ -617,21 +617,21 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
                 defaultValue: "charge",
                 required: true
             )
-        }        
+        }
         input(
             name: "${deviceTrait.name}.descriptiveCapacityRemainingAttribute",
             title: "Descriptive Capacity Remaining",
             type: "text",
             defaultValue: "descriptiveCapacityRemaining",
             required: true
-        )          
+        )
         input(
             name: "${deviceTrait.name}.capacityRemainingRawValue",
             title: "Capacity Remaining Value",
             type: "text",
             defaultValue: "capacityRemainingRawValue",
             required: true
-        )     
+        )
         input(
             name: "${deviceTrait.name}.capacityRemainingUnit",
             title: "Capacity Remaining Unit",
@@ -640,14 +640,14 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             multiple: false,
             required: true,
             submitOnChange: true
-        )            
+        )
         input(
             name: "${deviceTrait.name}.capacityUntilFullRawValue",
             title: "Capacity Until Full Value",
             type: "text",
             defaultValue: "capacityUntilFullRawValue",
             required: true
-        )     
+        )
         input(
             name: "${deviceTrait.name}.capacityUntilFullUnit",
             title: "Capacity Until Full Unit",
@@ -656,7 +656,7 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             multiple: false,
             required: true,
             submitOnChange: true
-        )              
+        )
         input(
             name: "${deviceTrait.name}.isChargingAttribute",
             title: "Charging Attribute",
@@ -670,22 +670,22 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
             type: "text",
             defaultValue: "true",
             required: true
-        )        
+        )
         input(
             name: "${deviceTrait.name}.isPluggedInAttribute",
             title: "ve",
             type: "text",
             defaultValue: "isPluggedIn",
             required: true
-        )  
+        )
         input(
             name: "${deviceTrait.name}.pluggedInValue",
             title: "Plugged In Value",
             type: "text",
             defaultValue: "true",
             required: true
-        )    
-        if ((deviceTrait.capacityRemainingUnit == "MILES") || (deviceTrait.capacityRemainingUnit == "KILOMETERS") || (deviceTrait.capacityUntilFullUnit == "MILES") || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {        
+        )
+        if ((deviceTrait.capacityRemainingUnit == "MILES") || (deviceTrait.capacityRemainingUnit == "KILOMETERS") || (deviceTrait.capacityUntilFullUnit == "MILES") || (deviceTrait.capacityUntilFullUnit == "KILOMETERS")) {
             input(
                 name: "${deviceTrait.name}.energyStorageDistanceUnitForUX",
                 title: "Supported Distance Units",
@@ -694,9 +694,9 @@ private deviceTraitPreferences_EnergyStorage(deviceTrait) {
                 multiple: false,
                 required: true,
                 submitOnChange: true
-            )     
-        }        
-    }    
+            )
+        }
+    }
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -1057,7 +1057,7 @@ def deviceTraitPreferences_Reboot(deviceTrait) {
             name: "${deviceTrait.name}.rebootCommand",
             title: "Reboot Command",
             type: "text",
-            defaultValue: "reboot",        
+            defaultValue: "reboot",
             required: true
         )
     }
@@ -1126,12 +1126,12 @@ def deviceTraitPreferences_SoftwareUpdate(deviceTrait) {
             type: "text",
             defaultValue: "lastSoftwareUpdateUnixTimestamp",
             required: true
-        )        
+        )
         input(
             name: "${deviceTrait.name}.softwareUpdateCommand",
             title: "Software Update Command",
             type: "text",
-            defaultValue: "softwareUpdate", 
+            defaultValue: "softwareUpdate",
             required: true
         )
     }
@@ -1471,14 +1471,14 @@ private deviceTraitPreferences_Timer(deviceTrait) {
             required: true,
             defaultValue: false,
             submitOnChange: true,
-        )          
+        )
         input(
             name: "${deviceTrait.name}.maxTimerLimitSec",
             title: "Maximum Timer Duration (seconds)",
             type: "integer",
             required: true,
             defaultValue: "86400"
-        )    
+        )
         if (!deviceTrait.commandOnlyTimer) {
             input(
                 name: "${deviceTrait.name}.timerRemainingSecAttribute",
@@ -1486,57 +1486,57 @@ private deviceTraitPreferences_Timer(deviceTrait) {
                 type: "text",
                 required: true,
                 defaultValue: "timeRemaining"
-            )        
+            )
             input(
                 name: "${deviceTrait.name}.timerPausedAttribute",
                 title: "Timer Paused Attribute",
                 type: "text",
                 required: true,
                 defaultValue: "sessionStatus"
-            )      
+            )
             input(
                 name: "${deviceTrait.name}.timerPausedValue",
                 title: "Timer Paused Value",
                 type: "text",
                 required: true,
                 defaultValue: "paused"
-            )          
-        }       
+            )
+        }
         input(
             name: "${deviceTrait.name}.timerStartCommand",
             title: "Timer Start Command",
             type: "text",
             required: true,
             defaultValue: "startTimer"
-        )            
+        )
         input(
             name: "${deviceTrait.name}.timerAdjustCommand",
             title: "Timer Adjust Command",
             type: "text",
             required: true,
             defaultValue: "setTimeRemaining"
-        )     
+        )
         input(
             name: "${deviceTrait.name}.timerCancelCommand",
             title: "Timer Cancel Command",
             type: "text",
             required: true,
             defaultValue: "cancel"
-        )     
+        )
         input(
             name: "${deviceTrait.name}.timerPauseCommand",
             title: "Timer Pause Command",
             type: "text",
             required: true,
             defaultValue: "pause"
-        )     
+        )
         input(
             name: "${deviceTrait.name}.timerResumeCommand",
             title: "Timer Resume Command",
             type: "text",
             required: true,
             defaultValue: "start"
-        )                  
+        )
     }
 }
 
@@ -2085,7 +2085,7 @@ private executeCommand_Reboot(deviceInfo, command) {
     def rebootTrait = deviceInfo.deviceType.traits.Reboot
     deviceInfo.device."${rebootTrait.rebootCommand}"()
     return [:]
-} 
+}
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_RotateAbsolute(deviceInfo, command) {
@@ -2097,7 +2097,7 @@ private executeCommand_RotateAbsolute(deviceInfo, command) {
     return [
         (rotationTrait.rotationAttribute): position
     ]
-} 
+}
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_SetFanSpeed(deviceInfo, command) {
@@ -2180,7 +2180,7 @@ private executeCommand_SoftwareUpdate(deviceInfo, command) {
     def softwareUpdateTrait = deviceInfo.deviceType.traits.SoftwareUpdate
     deviceInfo.device."${softwareUpdateTrait.softwareUpdateCommand}"()
     return [:]
-} 
+}
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_StartStop(deviceInfo, command) {
@@ -2279,7 +2279,7 @@ private executeCommand_TimerAdjust(deviceInfo, command) {
         ]
     }
     return retVal
-} 
+}
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_TimerCancel(deviceInfo, command) {
@@ -2287,7 +2287,7 @@ private executeCommand_TimerCancel(deviceInfo, command) {
     def TimerTrait = deviceInfo.deviceType.traits.Timer
     deviceInfo.device."${TimerTrait.timerCancelCommand}"()
     return [:]
-} 
+}
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_TimerPause(deviceInfo, command) {
@@ -2295,7 +2295,7 @@ private executeCommand_TimerPause(deviceInfo, command) {
     def TimerTrait = deviceInfo.deviceType.traits.Timer
     deviceInfo.device."${TimerTrait.timerPauseCommand}"()
     return [:]
-} 
+}
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_TimerResume(deviceInfo, command) {
@@ -2303,7 +2303,7 @@ private executeCommand_TimerResume(deviceInfo, command) {
     def TimerTrait = deviceInfo.deviceType.traits.Timer
     deviceInfo.device."${TimerTrait.timerResumeCommand}"()
     return [:]
-} 
+}
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_TimerStart(deviceInfo, command) {
@@ -2317,7 +2317,7 @@ private executeCommand_TimerStart(deviceInfo, command) {
         ]
     }
     return retVal
-} 
+}
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_volumeRelative(deviceInfo, command) {
@@ -2461,17 +2461,17 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
             rawValue: device.currentValue(deviceTrait.capacityRemainingRawValue).toInteger(),
             unit:     deviceTrait.capacityRemainingUnit
         ]
-    ]    
+    ]
     deviceState.capacityUntilFull = [
         [
             rawValue: device.currentValue(deviceTrait.capacityUntilFullRawValue).toInteger(),
-            unit:     deviceTrait.capacityUntilFullUnit      
-        ]       
+            unit:     deviceTrait.capacityUntilFullUnit
+        ]
     ]
     deviceState.isCharging = device.currentValue(deviceTrait.isChargingAttribute) == deviceTrait.chargingValue
     deviceState.isPluggedIn = device.currentValue(deviceTrait.isPluggedInAttribute) == deviceTrait.pluggedInValue
-       
-    return deviceState  
+
+    return deviceState
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -2651,15 +2651,15 @@ private deviceStateForTrait_TemperatureSetting(deviceTrait, device) {
 @SuppressWarnings('UnusedPrivateMethod')
 private deviceStateForTrait_Timer(deviceTrait, device) {
     def deviceState = [:]
-    if (!deviceTrait.commandOnlyTimer) {       
+    if (!deviceTrait.commandOnlyTimer) {
         deviceState = [
             timerRemainingSec: device.currentValue(deviceTrait.timerRemainingSecAttribute),
-            timerPaused: device.currentValue(deviceTrait.timerPausedAttribute) == deviceTrait.timerPausedValue     
+            timerPaused: device.currentValue(deviceTrait.timerPausedAttribute) == deviceTrait.timerPausedValue
         ]
     } else {
         // report no running timers
         deviceState = [
-            timerRemainingSec: -1   
+            timerRemainingSec: -1
         ]
     }
     return deviceState
@@ -2764,7 +2764,7 @@ private attributesForTrait_EnergyStorage(deviceTrait) {
         queryOnlyEnergyStorage:         deviceTrait.queryOnlyEnergyStorage,
         energyStorageDistanceUnitForUX: deviceTrait.energyStorageDistanceUnitForUX,
         isRechargeable:                 deviceTrait.isRechargeable
-    ]    
+    ]
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -2984,7 +2984,7 @@ private traitFromSettings_Brightness(traitName) {
 private traitFromSettings_CameraStream(traitName) {
     return [
         cameraStreamAttribute:          settings."${traitName}.cameraStreamAttribute",
-        cameraStreamSupportedProtocols: settings."${traitName}.cameraStreamSupportedProtocols",   
+        cameraStreamSupportedProtocols: settings."${traitName}.cameraStreamSupportedProtocols",
         commands:              []
     ]
 }
@@ -3038,25 +3038,25 @@ private traitFromSettings_Dock(traitName) {
 private traitFromSettings_EnergyStorage(traitName) {
     def energyStorageTrait = [
         energyStorageDistanceUnitForUX:           settings."${traitName}.energyStorageDistanceUnitForUX",
-        isRechargeable:                           settings."${traitName}.isRechargeable",        
+        isRechargeable:                           settings."${traitName}.isRechargeable",
         queryOnlyEnergyStorage:                   settings."${traitName}.queryOnlyEnergyStorage",
         descriptiveCapacityRemainingAttribute:    settings."${traitName}.descriptiveCapacityRemainingAttribute",
         capacityRemainingRawValue:                settings."${traitName}.capacityRemainingRawValue",
         capacityRemainingUnit:                    settings."${traitName}.capacityRemainingUnit",
         capacityUntilFullRawValue:                settings."${traitName}.capacityUntilFullRawValue",
         capacityUntilFullUnit:                    settings."${traitName}.capacityUntilFullUnit",
-        isChargingAttribute:                      settings."${traitName}.isChargingAttribute",      
-        chargingValue:                            settings."${traitName}.chargingValue",     
+        isChargingAttribute:                      settings."${traitName}.isChargingAttribute",
+        chargingValue:                            settings."${traitName}.chargingValue",
         isPluggedInAttribute:                     settings."${traitName}.isPluggedInAttribute",
         pluggedInValue:                           settings."${traitName}.pluggedInValue",
         chargeCommand:                            settings."${traitName}.chargeCommand",
-        commands:                                 []  
-    ]  
+        commands:                                 []
+    ]
     if (!energyStorageTrait.queryOnlyEnergyStorage) {
         energyStorageTrait.commands += ["Charge"]
     }
 
-    return energyStorageTrait     
+    return energyStorageTrait
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -3221,7 +3221,7 @@ private traitFromSettings_Scene(traitName) {
 @SuppressWarnings('UnusedPrivateMethod')
 private traitFromSettings_SoftwareUpdate(traitName) {
     return [
-        lastSoftwareUpdateUnixTimestampSecAttribute:    settings."${traitName}.lastSoftwareUpdateUnixTimestampSecAttribute",        
+        lastSoftwareUpdateUnixTimestampSecAttribute:    settings."${traitName}.lastSoftwareUpdateUnixTimestampSecAttribute",
         softwareUpdateCommand:                          settings."${traitName}.softwareUpdateCommand",
         commands:                                       ["Software Update"]
     ]
@@ -3382,15 +3382,15 @@ private traitFromSettings_Timer(traitName) {
         commandOnlyTimer:                 settings."${traitName}.commandOnlyTimer",
 
         commands:                         ["Start","Adjust","Cancel","Pause","Resume"]
-    ]    
+    ]
     if (!timerTrait.commandOnlyTimer) {
         timerTrait << [
             timerRemainingSecAttribute:   settings."${traitName}.timerRemainingSecAttribute",
             timerPausedAttribute:         settings."${traitName}.timerPausedAttribute",
-            timerPausedValue:             settings."${traitName}.timerPausedValue",            
-        ]        
+            timerPausedValue:             settings."${traitName}.timerPausedValue",
+        ]
     }
-    return timerTrait    
+    return timerTrait
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -3502,7 +3502,7 @@ private deleteDeviceTrait_Brightness(deviceTrait) {
 @SuppressWarnings('UnusedPrivateMethod')
 private deleteDeviceTrait_CameraStream(deviceTrait) {
     app.removeSetting("${deviceTrait.name}.cameraStreamAttribute")
-    app.removeSetting("${deviceTrait.name}.cameraStreamSupportedProtocols")    
+    app.removeSetting("${deviceTrait.name}.cameraStreamSupportedProtocols")
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -3540,10 +3540,10 @@ private deleteDeviceTrait_EnergyStorage(deviceTrait) {
     app.removeSetting("${deviceTrait.name}.capacityRemainingUnit")
     app.removeSetting("${deviceTrait.name}.capacityUntilFullRawValue")
     app.removeSetting("${deviceTrait.name}.capacityUntilFullUnit")
-    app.removeSetting("${deviceTrait.name}.isChargingAttribute")  
-    app.removeSetting("${deviceTrait.name}.chargingValue")  
-    app.removeSetting("${deviceTrait.name}.isPluggedInAttribute")    
-    app.removeSetting("${deviceTrait.name}.pluggedInValue")    
+    app.removeSetting("${deviceTrait.name}.isChargingAttribute")
+    app.removeSetting("${deviceTrait.name}.chargingValue")
+    app.removeSetting("${deviceTrait.name}.isPluggedInAttribute")
+    app.removeSetting("${deviceTrait.name}.pluggedInValue")
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -3616,7 +3616,7 @@ private deleteDeviceTrait_OpenClose(deviceTrait) {
 
 @SuppressWarnings('UnusedPrivateMethod')
 private deleteDeviceTrait_Reboot(deviceTrait) {
-    app.removeSetting("${deviceTrait.name}.rebootCommand")    
+    app.removeSetting("${deviceTrait.name}.rebootCommand")
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -3635,8 +3635,8 @@ private deleteDeviceTrait_Scene(deviceTrait) {
 
 @SuppressWarnings('UnusedPrivateMethod')
 private deleteDeviceTrait_SoftwareUpdate(deviceTrait) {
-    app.removeSetting("${deviceTrait.name}.lastSoftwareUpdateUnixTimestampSecAttribute")      
-    app.removeSetting("${deviceTrait.name}.softwareUpdateCommand")          
+    app.removeSetting("${deviceTrait.name}.lastSoftwareUpdateUnixTimestampSecAttribute")
+    app.removeSetting("${deviceTrait.name}.softwareUpdateCommand")
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -3703,7 +3703,7 @@ private deleteDeviceTrait_Timer(deviceTrait) {
     app.removeSetting("${deviceTrait.name}.timerCancelCommand")
     app.removeSetting("${deviceTrait.name}.timerPauseCommand")
     app.removeSetting("${deviceTrait.name}.timerResumeCommand")
-    app.removeSetting("${deviceTrait.name}.timerPausedValue")    
+    app.removeSetting("${deviceTrait.name}.timerPausedValue")
 }
 
 @SuppressWarnings('UnusedPrivateMethod')

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
Added Energy Storage, Software Update, Reboot, Media State and Timer Traits.  Added missing camera trait protocol attributes.

**Notes:**

**Media State:**  Trait is properly expressed to Google, but I am unsure of what the voice commands are to query the playback and activity states.

**Timer:** Trait is properly expressed to Google, query commands function properly, the control commands are untested.  I am unsure of what Google voice commands are used to control the Timer Trait.  When trying to control the device, Google responds with a "Actually, <device> does not support that functionality."  It appears Google is thinking the commands are for the Media Control Trait (start, pause, resume, adjust, cancel).

I have created a Hubitat Virtual Timer driver that directly links to the Timer Trait for testing:
https://github.com/wir3z/hubitat-drivers/blob/master/Hubitat%20Timer%20driver.groovy

