### PR TITLE
[v2] Allow immediate response

### DIFF
--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -1771,27 +1771,27 @@ private handleExecuteRequest(request) {
                 }
             }
         }
-        // Wait up to 5 seconds for devices to report their new state
-        // Reduce wait time to 0.1 second if immediate response requested
-        def waitTime = (settings.immediateResponse) ? 1 : 50
-        for (def i = 0; i < waitTime; ++i) {
-            def ready = attrsToAwait.every { device, attributes ->
-                attributes.every { attrName, attrValue ->
-                    attributeHasExpectedValue(device, attrName, attrValue)
+        // Skip loop if immediateResponse desired
+        if (!settings.immediateResponse) {
+            // Wait up to 5 seconds for devices to report their new state
+            for (def i = 0; i < 50; ++i) {
+                def ready = attrsToAwait.every { device, attributes ->
+                    attributes.every { attrName, attrValue ->
+                        attributeHasExpectedValue(device, attrName, attrValue)
+                    }
                 }
-            }
-            if (ready) {
-                break
-            } else {
-                pauseExecution(100)
+                if (ready) {
+                    break
+                } else {
+                    pauseExecution(100)
+                }
             }
         }
         // Now build our response message
         devices.each { device ->
             def result = results[device.device]
             result.ids = [device.device.id]
-            // Return true regardless of decvice state if immediate reponse requested
-            if (result.status == "SUCCESS" || settings.immediateResponse) {
+            if (result.status == "SUCCESS") {
                 def deviceState = [
                     online: true
                 ]
@@ -1803,7 +1803,6 @@ private handleExecuteRequest(request) {
             resp.payload.commands << result
         }
     }
-
     LOGGER.debug(resp)
     return resp
 }

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -178,6 +178,12 @@ def mainPreferences() {
                 type: "bool",
                 defaultValue: false
             )
+            input(
+                name: "immediateResponse",
+                title: "Respond to Google before device is at new state",
+                type: "bool",
+                defaultValue: false
+            )
         }
         section("Global PIN Codes") {
             globalPinCodes?.pinCodes?.each { pinCode ->
@@ -1766,7 +1772,9 @@ private handleExecuteRequest(request) {
             }
         }
         // Wait up to 5 seconds for devices to report their new state
-        for (def i = 0; i < 50; ++i) {
+        // Reduce wait time to 0.1 second if immediate response requested
+        def waitTime = (settings.immediateResponse) ? 1 : 50
+        for (def i = 0; i < waitTime; ++i) {
             def ready = attrsToAwait.every { device, attributes ->
                 attributes.every { attrName, attrValue ->
                     attributeHasExpectedValue(device, attrName, attrValue)
@@ -1782,7 +1790,8 @@ private handleExecuteRequest(request) {
         devices.each { device ->
             def result = results[device.device]
             result.ids = [device.device.id]
-            if (result.status == "SUCCESS") {
+            // Return true regardless of decvice state if immediate reponse requested
+            if (result.status == "SUCCESS" || settings.immediateResponse) {
                 def deviceState = [
                     online: true
                 ]

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.29.1",
+  "version": "0.30.0",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
This is an update on top of #42 and includes the commits from that PR in this one.

In this PR, I update each execute handler to return both the attributes to await *and* the new assumed states of the device.

I also changed the logic to keep the poll for the attributes to await when immediate response is enabled, but shorten the poll from 5000 ms to 1000 ms.

For both immediate response and the previous behavior, we now return `PENDING` instead of `SUCCESS` when the device attributes have not yet all been reached.
