### PR TITLE
Fix a bug recently introduced in the Toggles trait

### DIFF
--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2222,7 +2222,9 @@ private executeCommand_SetToggles(deviceInfo, command) {
             device: deviceInfo.device
         ]
         checkMfa(deviceInfo.deviceType, "${toggle.labels[0]} ${toggleValue ? "On" : "Off"}", command)
-        attrsToCheck << executeCommand_OnOff(fakeDeviceInfo, [params: [on: toggleValue]])
+        def onOffResponse = executeCommand_OnOff(fakeDeviceInfo, [params: [on: toggleValue]])
+        attrsToCheck << onOffResponse[0]
+        states << onOffResponse[1]
     }
     return [attrsToCheck, states]
 }

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
The Toggles trait is unique in that its command executor method
calls the `executeCommand_OnOff` method to do its actual work.  #69
recently changed the return value of the command executors but missed
this one case.  This restores Toggles to full functionality.