### PR TITLE
Fix SYNC handler on Hubitat 2.2.6 and earlier

### DIFF
--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
This gracefully handles the case when the `Device` class's `roomId`
property is missing, as is the case on Hubitat versions prior to
2.2.7.  I originally thought it would just be returned as `null`,
but it seems to behave slightly differently than the app class.