### PR TITLE
Treat level/position of 99 as 100 instead of trying to scale

### DIFF
--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.31.4",
+  "version": "0.31.5",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
This fixes #76 by treating level/position of 99 as 100 for Z-Wave devices which don't map their ranges to the Hubitat range of [0..99].

I tested this with Z-Wave dimmers and window blinds.