### PR TITLE
Add a reverseDirection toggle to the Open/Close trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,8 @@ The Open/Close trait is used for devices that can be opened and closed such as d
 - Query Only Open/Close: Should be set if this device can only be queried but not controlled (a contact sensor, for example).
 - Discrete Only Open/Close: Should be left unset if this device can be partially opened and set if the device can only be fully opened or closed.  The other configuration parameters change depending on if this is set or not:
     - Unset:
-        - Open/Close Attribute: The device attribute used to query the current state of the device.  Should be in the range 0-100 with 0 being fully closed and 100 being fully open.
+        - Open/Close Attribute: The device attribute used to query the current state of the device.  Should be in the range 0-100.
+        - Reverse Direction: Normally the Open/Close Attribute uses 0 to indicate fully closed and 100 to indicate fully open.  Set this toggle to reverse that and use 100 to indicate fully closed and 0 to indicate fully open.
         - Open/Close Command: Only available if Query Only Open/Close is unset.  A device command used to open or close the device.  Should accept a parameter in the range 0-100 representing the percentage of the way to open the device.  Mapped to `setPosition` by default.
     - Set:
         - Open/Close Attribute: The device attribute used to query the current state of the device.  Should always be either Open Value or Closed Value.

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.31.5",
+  "version": "0.31.6",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
Some window shade device drivers use position 0 to indicate fully
open (AKA 0% unrolled) and 100 to indicate fully closed.  This is
backwards from what Google uses, so add a toggle to support those
drivers.

Closes #26 