### PR TITLE
Log a warning if a device is selected as multiple device types

### DIFF
--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.31.6",
+  "version": "0.31.7",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
The app currently doesn't try to reconcile when a device is selected as
multiple device types.  Previously, it would just send two device
configurations to Google with the same ID, causing Google to reject the
SYNC response outright.  This changes the behavior in that situation to
log a warning and ignore subsequent definitions of the same device so
that one misconfigured device doesn't block the user's other devices
from being synced with Google.