### PR TITLE
Control Fan Using Percentages

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ The Fan Speed trait is primarily used for fan controllers with multiple speed se
 - Google Home Level Names for {speed} - A comma-separated list of names that you will use to reference this fan speed when interacting with the Google Assistant.  By default, the name of the speed in Hubitat is used.
 - Reversible: Select this if the fan direction can be reversed
 - Reverse Command: Only available if "Reversible" is selected.  A device command that can be used to reverse the device's fan direction.
+- Supports Percentage Settings: Select this if you want to command the fan using percentages
+- Current Fan Speed Percentage Attribute: The device attribute used to query the current fan speed percentage of the device.  Maps to the `level` attribute by default.
+- Fan Speed Percent Command: A device command used to set the fan speed of the device i percentage. Maps to the `setLevel` command by default.
 
 ### Humidity Setting
 

--- a/codenarc.xml
+++ b/codenarc.xml
@@ -344,7 +344,7 @@
   <rule class='org.codenarc.rule.unnecessary.UnnecessaryDefInVariableDeclarationRule'/>
   <rule class='org.codenarc.rule.unnecessary.UnnecessaryDotClassRule'/>
   <rule class='org.codenarc.rule.unnecessary.UnnecessaryDoubleInstantiationRule'/>
-  <rule class='org.codenarc.rule.unnecessary.UnnecessaryElseStatementRule'/>
+  <!--<rule class='org.codenarc.rule.unnecessary.UnnecessaryElseStatementRule'/>-->
   <rule class='org.codenarc.rule.unnecessary.UnnecessaryFinalOnPrivateMethodRule'/>
   <rule class='org.codenarc.rule.unnecessary.UnnecessaryFloatInstantiationRule'/>
   <rule class='org.codenarc.rule.unnecessary.UnnecessaryGetterRule'/>

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -764,6 +764,35 @@ private deviceTraitPreferences_FanSpeed(deviceTrait) {
             )
         }
     }
+    
+       section("Supports Percentage Settings") {
+        input(
+            name: "${deviceTrait.name}.supportsFanSpeedPercent",
+            title: "Supports Fan Speed Percent",
+            type: "bool",
+            defaultValue: false,
+            submitOnChange: true
+        )
+
+        if (settings."${deviceTrait.name}.supportsFanSpeedPercent") {
+            
+         input(
+            name: "${deviceTrait.name}.fanSpeedPercentAttribute",
+            title: "Current Fan Speed Percentage Attribute",
+            type: "text",
+            defaultValue: "level",
+            required: true
+            )           
+            
+            input(
+                name: "${deviceTrait.name}.supportsFanSpeedPercentCommand",
+                title: "Fan Speed Percent Command",
+                type: "text",
+                defaultValue: "setLevel",
+                required: true
+            )
+        }
+    }
 }
 
 @SuppressWarnings('UnusedPrivateMethod')

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -3296,7 +3296,6 @@ private traitFromSettings_FanSpeed(traitName) {
     if (fanSpeedMapping.supportsFanSpeedPercent) {
         fanSpeedMapping.setFanSpeedPercentCommand = settings."${traitName}.setFanSpeedPercentCommand"
         fanSpeedMapping.currentFanSpeedPercent = settings."${traitName}.currentFanSpeedPercent"
-        fanSpeedMapping.commands << "Set Percentage"
     }
     settings."${traitName}.fanSpeeds"?.each { fanSpeed ->
         fanSpeedMapping.fanSpeeds[fanSpeed] = settings."${traitName}.speed.${fanSpeed}.googleNames"

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2663,19 +2663,18 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
 
 @SuppressWarnings('UnusedPrivateMethod')
 private deviceStateForTrait_FanSpeed(deviceTrait, device) {
-    def currentSpeed = device.currentValue(deviceTrait.currentSpeedAttribute)
+    def currentSpeedSetting = device.currentValue(deviceTrait.currentSpeedAttribute)
+
+    def fanSpeedState = [
+        currentFanSpeedSetting: currentSpeedSetting
+    ]
 
     if (deviceTrait.supportsFanSpeedPercent) {
         def currentSpeedPercent = hubitatPercentageToGoogle(device.currentValue(deviceTrait.currentFanSpeedPercent))
-        return [
-            currentFanSpeedSetting: currentSpeed,
-            currentFanSpeedPercent: currentSpeedPercent
-        ]
-    } else {
-        return [
-            currentFanSpeedSetting: currentSpeed
-        ]
+        fanSpeedState.currentFanSpeedPercent = currentSpeedPercent
     }
+
+    return fanSpeedState
 }
 
 @SuppressWarnings('UnusedPrivateMethod')

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2213,7 +2213,7 @@ private executeCommand_SetFanSpeed(deviceInfo, command) {
         deviceInfo.device."${fanSpeedTrait.setFanSpeedPercentCommand}"(fanSpeedPercent)
         return [
             [
-                (fanSpeedTrait.currentFanSpeedPercent): fanSpeedpercent,
+                (fanSpeedTrait.currentFanSpeedPercent): fanSpeedPercent,
             ],
             [
                 currentFanSpeedPercent: fanSpeedPercent,
@@ -2231,7 +2231,7 @@ private executeCommand_SetFanSpeed(deviceInfo, command) {
             ],
         ]
     }
-    }
+}
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_SetHumidity(deviceInfo, command) {

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2213,7 +2213,7 @@ private executeCommand_SetFanSpeed(deviceInfo, command) {
 		deviceInfo.device."${fanSpeedTrait.setFanSpeedPercentCommand}"(fanSpeedpercent)
 		return [
 			[
-				(fanSpeedTrait.currentSpeedAttribute): fanSpeedpercent,
+				(fanSpeedTrait.currentFanSpeedPercent): fanSpeedpercent,
 			],
 			[
 				currentFanSpeedSetting: fanSpeedpercent,

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -776,13 +776,13 @@ private deviceTraitPreferences_FanSpeed(deviceTrait) {
         )
 
         if (settings."${deviceTrait.name}.supportsFanSpeedPercent") {
-			input(
-				name: "${deviceTrait.name}.currentFanSpeedPercent",
-				title: "Current Fan Speed Percentage Attribute",
-				type: "text",
-				defaultValue: "level",
-				required: true
-				)
+            input(
+                name: "${deviceTrait.name}.currentFanSpeedPercent",
+                title: "Current Fan Speed Percentage Attribute",
+                type: "text",
+                defaultValue: "level",
+                required: true
+                )
 
             input(
                 name: "${deviceTrait.name}.setFanSpeedPercentCommand",
@@ -2204,34 +2204,34 @@ private executeCommand_RotateAbsolute(deviceInfo, command) {
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_SetFanSpeed(deviceInfo, command) {
-	checkMfa(deviceInfo.deviceType, "Set Fan Speed", command)
-	def fanSpeedTrait = deviceInfo.deviceType.traits.FanSpeed
+    checkMfa(deviceInfo.deviceType, "Set Fan Speed", command)
+    def fanSpeedTrait = deviceInfo.deviceType.traits.FanSpeed
 
-	if (fanSpeedTrait.supportsFanSpeedPercent && command.params.fanSpeedPercent) {
-		def fanSpeedPercent = command.params.fanSpeedPercent
+    if (fanSpeedTrait.supportsFanSpeedPercent && command.params.fanSpeedPercent) {
+        def fanSpeedPercent = command.params.fanSpeedPercent
 
-		deviceInfo.device."${fanSpeedTrait.setFanSpeedPercentCommand}"(fanSpeedPercent)
-		return [
-			[
-				(fanSpeedTrait.currentFanSpeedPercent): fanSpeedpercent,
-			],
-			[
-				currentFanSpeedPercent: fanSpeedPercent,
-			],
-		]
-	} else {
-		def fanSpeed = command.params.fanSpeed
-		deviceInfo.device."${fanSpeedTrait.setFanSpeedCommand}"(fanSpeed)
-		return [
-			[
-				(fanSpeedTrait.currentSpeedAttribute): fanSpeed,
-			],
-			[
-				currentFanSpeedSetting: fanSpeed,
-			],
-		]
-	}
-	}
+        deviceInfo.device."${fanSpeedTrait.setFanSpeedPercentCommand}"(fanSpeedPercent)
+        return [
+            [
+                (fanSpeedTrait.currentFanSpeedPercent): fanSpeedpercent,
+            ],
+            [
+                currentFanSpeedPercent: fanSpeedPercent,
+            ],
+        ]
+    } else {
+        def fanSpeed = command.params.fanSpeed
+        deviceInfo.device."${fanSpeedTrait.setFanSpeedCommand}"(fanSpeed)
+        return [
+            [
+                (fanSpeedTrait.currentSpeedAttribute): fanSpeed,
+            ],
+            [
+                currentFanSpeedSetting: fanSpeed,
+            ],
+        ]
+    }
+    }
 
 @SuppressWarnings('UnusedPrivateMethod')
 private executeCommand_SetHumidity(deviceInfo, command) {
@@ -2665,17 +2665,17 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
 private deviceStateForTrait_FanSpeed(deviceTrait, device) {
     def currentSpeed = device.currentValue(deviceTrait.currentSpeedAttribute)
 
-	if (deviceTrait.supportsFanSpeedPercent) {
-		def currentSpeedPercent = hubitatPercentageToGoogle(device.currentValue(deviceTrait.currentFanSpeedPercent))
-		return [
-			currentFanSpeedSetting: currentSpeed,
-			currentFanSpeedPercent: currentSpeedPercent
-		]
-	} else {
-		return [
-			currentFanSpeedSetting: currentSpeed
-		]
-	}
+    if (deviceTrait.supportsFanSpeedPercent) {
+        def currentSpeedPercent = hubitatPercentageToGoogle(device.currentValue(deviceTrait.currentFanSpeedPercent))
+        return [
+            currentFanSpeedSetting: currentSpeed,
+            currentFanSpeedPercent: currentSpeedPercent
+        ]
+    } else {
+        return [
+            currentFanSpeedSetting: currentSpeed
+        ]
+    }
 }
 
 @SuppressWarnings('UnusedPrivateMethod')
@@ -3288,15 +3288,15 @@ private traitFromSettings_FanSpeed(traitName) {
         fanSpeeds:             [:],
         reversible:            settings."${traitName}.reversible",
         commands:              ["Set Fan Speed"],
-		supportsFanSpeedPercent: settings."${traitName}.supportsFanSpeedPercent"
+        supportsFanSpeedPercent: settings."${traitName}.supportsFanSpeedPercent"
     ]
     if (fanSpeedMapping.reversible) {
         fanSpeedMapping.reverseCommand = settings."${traitName}.reverseCommand"
         fanSpeedMapping.commands << "Reverse"
     }
-	if (fanSpeedMapping.supportsFanSpeedPercent) {
+    if (fanSpeedMapping.supportsFanSpeedPercent) {
         fanSpeedMapping.setFanSpeedPercentCommand = settings."${traitName}.setFanSpeedPercentCommand"
-		fanSpeedMapping.currentFanSpeedPercent = settings."${traitName}.currentFanSpeedPercent"
+        fanSpeedMapping.currentFanSpeedPercent = settings."${traitName}.currentFanSpeedPercent"
         fanSpeedMapping.commands << "Set Percentage"
     }
     settings."${traitName}.fanSpeeds"?.each { fanSpeed ->

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2216,7 +2216,7 @@ private executeCommand_SetFanSpeed(deviceInfo, command) {
 				(fanSpeedTrait.currentFanSpeedPercent): fanSpeedpercent,
 			],
 			[
-				currentFanSpeedSetting: fanSpeedpercent,
+				currentFanSpeedPercent: fanSpeedpercent,
 			],
 		]
 	} else {

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -765,7 +765,7 @@ private deviceTraitPreferences_FanSpeed(deviceTrait) {
             )
         }
     }
-    
+
        section("Supports Percentage Settings") {
         input(
             name: "${deviceTrait.name}.supportsFanSpeedPercent",
@@ -776,15 +776,14 @@ private deviceTraitPreferences_FanSpeed(deviceTrait) {
         )
 
         if (settings."${deviceTrait.name}.supportsFanSpeedPercent") {
-            
-         input(
-            name: "${deviceTrait.name}.currentFanSpeedPercent",
-            title: "Current Fan Speed Percentage Attribute",
-            type: "text",
-            defaultValue: "level",
-            required: true
-            )           
-            
+			input(
+				name: "${deviceTrait.name}.currentFanSpeedPercent",
+				title: "Current Fan Speed Percentage Attribute",
+				type: "text",
+				defaultValue: "level",
+				required: true
+				)
+
             input(
                 name: "${deviceTrait.name}.setFanSpeedPercentCommand",
                 title: "Fan Speed Percent Command",
@@ -2219,8 +2218,7 @@ private executeCommand_SetFanSpeed(deviceInfo, command) {
 			[
 				currentFanSpeedSetting: fanSpeedpercent,
 			],
-		]	
-	
+		]
 	} else {
 		def fanSpeed = command.params.fanSpeed
 		deviceInfo.device."${fanSpeedTrait.setFanSpeedCommand}"(fanSpeed)
@@ -3788,10 +3786,9 @@ private deleteDeviceTrait_FanSpeed(deviceTrait) {
     deviceTrait.fanSpeeds.each { fanSpeed, googleNames ->
         app.removeSetting("${deviceTrait.name}.speed.${fanSpeed}.googleNames")
     }
-    app.removeSetting("${deviceTrait.name}.supportsFanSpeedPercent")	
-    app.removeSetting("${deviceTrait.name}.setFanSpeedPercentCommand")	
-    app.removeSetting("${deviceTrait.name}.currentFanSpeedPercent")	
-	
+    app.removeSetting("${deviceTrait.name}.supportsFanSpeedPercent")
+    app.removeSetting("${deviceTrait.name}.setFanSpeedPercentCommand")
+    app.removeSetting("${deviceTrait.name}.currentFanSpeedPercent")
     app.removeSetting("${deviceTrait.name}.fanSpeeds")
 }
 

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -766,7 +766,7 @@ private deviceTraitPreferences_FanSpeed(deviceTrait) {
         }
     }
 
-       section("Supports Percentage Settings") {
+    section("Supports Percentage Settings") {
         input(
             name: "${deviceTrait.name}.supportsFanSpeedPercent",
             title: "Supports Fan Speed Percent",
@@ -782,7 +782,7 @@ private deviceTraitPreferences_FanSpeed(deviceTrait) {
                 type: "text",
                 defaultValue: "level",
                 required: true
-                )
+            )
 
             input(
                 name: "${deviceTrait.name}.setFanSpeedPercentCommand",

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2208,15 +2208,15 @@ private executeCommand_SetFanSpeed(deviceInfo, command) {
 	def fanSpeedTrait = deviceInfo.deviceType.traits.FanSpeed
 
 	if (fanSpeedTrait.supportsFanSpeedPercent && command.params.fanSpeedPercent) {
-		def fanSpeedpercent = command.params.fanSpeedPercent
+		def fanSpeedPercent = command.params.fanSpeedPercent
 
-		deviceInfo.device."${fanSpeedTrait.setFanSpeedPercentCommand}"(fanSpeedpercent)
+		deviceInfo.device."${fanSpeedTrait.setFanSpeedPercentCommand}"(fanSpeedPercent)
 		return [
 			[
 				(fanSpeedTrait.currentFanSpeedPercent): fanSpeedpercent,
 			],
 			[
-				currentFanSpeedPercent: fanSpeedpercent,
+				currentFanSpeedPercent: fanSpeedPercent,
 			],
 		]
 	} else {
@@ -2669,7 +2669,7 @@ private deviceStateForTrait_FanSpeed(deviceTrait, device) {
 		def currentSpeedPercent = hubitatPercentageToGoogle(device.currentValue(deviceTrait.currentFanSpeedPercent))
 		return [
 			currentFanSpeedSetting: currentSpeed,
-			currentFanspeedPercent: currentSpeedPercent
+			currentFanSpeedPercent: currentSpeedPercent
 		]
 	} else {
 		return [

--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -2665,8 +2665,7 @@ private deviceStateForTrait_EnergyStorage(deviceTrait, device) {
 private deviceStateForTrait_FanSpeed(deviceTrait, device) {
     def currentSpeed = device.currentValue(deviceTrait.currentSpeedAttribute)
 
-	if (deviceTrait.supportsFanSpeedPercent)
-	{
+	if (deviceTrait.supportsFanSpeedPercent) {
 		def currentSpeedPercent = hubitatPercentageToGoogle(device.currentValue(deviceTrait.currentFanSpeedPercent))
 		return [
 			currentFanSpeedSetting: currentSpeed,

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.31.7",
+  "version": "0.32.0",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
Added support for the FanSpeed supportsFanSpeedPercent trait.  Works for Hubitat fans having a "level" setting. Allows command using statements like "Set fan to 50 percent"
