### PR TITLE
Add error handling on QUERY intents

### DIFF
--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
This adds error handling to QUERY intent requests to avoid having one
misconfigured device prevent all other devices from reporting.