### PR TITLE
Normalize rounding of temperatures to one decimal place

### DIFF
--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
Previously we were only rounding temperatures if we did a conversion.
This changes all temperature handling to round to one decimal place
regardless of if we do a conversion or not.