### PR TITLE
Tolerate attempting to round null

### DIFF
--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -70,6 +70,7 @@
 //                 - Added support for returning the matching user position for Arm/Disarm and Lock/Unlock to the device driver
 //   * Jun 21 2022 - Apply rounding more consistently to temperatures
 //   * Jun 21 2022 - Added SensorState Trait
+//   * Jun 23 2022 - Fix error attempting to round null
 
 import groovy.json.JsonException
 import groovy.json.JsonOutput
@@ -4588,7 +4589,12 @@ private allKnownDevices() {
 
 private roundTo(number, decimalPlaces) {
     def factor = Math.max(1, 10 * decimalPlaces)
-    return Math.round(number * factor) / factor
+    try {
+        return Math.round(number * factor) / factor
+    catch (NullPointerException e) {
+        LOGGER.exception("Attempted to round null!", e)
+        return null
+    }
 }
 
 private googlePercentageToHubitat(percentage) {

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
There was a NullPointerException reported from passing null into the
roundTo method.  I'm not exactly sure what's null that's being passed
in, so this makes the method tolerate the null and generate a stack
trace so I can track it down.