### PR TITLE
Small fix to avoid trying to report empty device state

### DIFF
--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -165,23 +165,28 @@ private reportStateForDevices(devices) {
         if (deviceState.size()) {
             req.payload.devices.states."${deviceId}" = deviceState
         } else {
-            LOGGER.debug("Not reporting state for device ${deviceInfo.device} to Home Graph (no state -- maybe a scene?)")
+            LOGGER.debug(
+                "Not reporting state for device ${deviceInfo.device} to Home Graph (no state -- maybe a scene?)"
+            )
         }
-
     }
 
-    def token = fetchOAuthToken()
-    params = [
-        uri: "https://homegraph.googleapis.com/v1/devices:reportStateAndNotification",
-        headers: [
-            Authorization: "Bearer REDACTED",
-        ],
-        body: req,
-    ]
-    LOGGER.debug("Posting device state requestId=${requestId}: ${params}")
-    params.headers.authorization = "Bearer ${token}"
-    httpPostJson(params) { resp ->
-        LOGGER.debug("Finished posting device state requestId=${requestId}")
+    if (req.payload.devices.states.size()) {
+        def token = fetchOAuthToken()
+        params = [
+            uri: "https://homegraph.googleapis.com/v1/devices:reportStateAndNotification",
+            headers: [
+                Authorization: "Bearer REDACTED",
+            ],
+            body: req,
+        ]
+        LOGGER.debug("Posting device state requestId=${requestId}: ${params}")
+        params.headers.authorization = "Bearer ${token}"
+        httpPostJson(params) { resp ->
+            LOGGER.debug("Finished posting device state requestId=${requestId}")
+        }
+    } else {
+        LOGGER.debug("No device state to report; not sending device state report to Home Graph")
     }
 }
 

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
The app was getting bad request errors when trying to report state for stateless devices like scenes and modes.  This avoids attempting to report state for devices with no states.