### PR TITLE
Uppercase values sent for MediaState attributes

### DIFF
--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -74,6 +74,7 @@
 //   * Sep 08 2022 - Fix SensorState labels
 //   * Oct 18 2022 - Added TransportControl Trait
 //   * Nov 30 2022 - Implement RequestSync and ReportState APIs
+//   * Feb 03 2023 - Uppercase values sent for MediaState attributes
 
 import groovy.json.JsonException
 import groovy.json.JsonOutput
@@ -182,8 +183,15 @@ private reportStateForDevices(devices) {
         ]
         LOGGER.debug("Posting device state requestId=${requestId}: ${params}")
         params.headers.authorization = "Bearer ${token}"
-        httpPostJson(params) { resp ->
-            LOGGER.debug("Finished posting device state requestId=${requestId}")
+        try {
+            httpPostJson(params) { resp ->
+                LOGGER.debug("Finished posting device state requestId=${requestId}")
+            }
+        } catch (Exception ex) {
+            LOGGER.exception(
+                "Error posting device state:\nrequest=${req}\n",
+                ex
+            )
         }
     } else {
         LOGGER.debug("No device state to report; not sending device state report to Home Graph")
@@ -3260,8 +3268,8 @@ private deviceStateForTrait_LockUnlock(deviceTrait, device) {
 @SuppressWarnings('UnusedPrivateMethod')
 private deviceStateForTrait_MediaState(deviceTrait, device) {
     return [
-        activityState: device.currentValue(deviceTrait.activityStateAttribute),
-        playbackState: device.currentValue(deviceTrait.playbackStateAttribute)
+        activityState: device.currentValue(deviceTrait.activityStateAttribute)?.toUpperCase(),
+        playbackState: device.currentValue(deviceTrait.playbackStateAttribute)?.toUpperCase()
     ]
 }
 

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.36.1",
+  "version": "0.37.0",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
This PR includes a tweak to the error reporting when posting device state requests so that failures will also output the request body that caused the error. I found it easier to include in the error message as there's less content in the logs to dig through to identify the request that failed. No problem if you want me to remove this as I see that debug logging can be enabled to output the same info if needed. 