### PR TITLE
Fix hub version comparison

### DIFF
--- a/google-home-community.groovy
+++ b/google-home-community.groovy
@@ -75,6 +75,7 @@
 //   * Oct 18 2022 - Added TransportControl Trait
 //   * Nov 30 2022 - Implement RequestSync and ReportState APIs
 //   * Feb 03 2023 - Uppercase values sent for MediaState attributes
+//   * Mar 06 2023 - Fix hub version comparison
 
 import groovy.json.JsonException
 import groovy.json.JsonOutput
@@ -242,6 +243,8 @@ private hubVersionLessThan(versionString) {
     for (def i = 0; i < targetVersion.length; ++i) {
         if ((hubVersion[i] as int) < (targetVersion[i] as int)) {
             return true
+        } else if ((hubVersion[i] as int) > (targetVersion[i] as int)) {
+            return false
         }
     }
     return false

--- a/packageManifest.json
+++ b/packageManifest.json
@@ -1,7 +1,7 @@
 {
   "packageName": "Google Home Community",
   "author": "Miles Budnek",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "minimumHEVersion": "0.0",
   "documentationLink": "https://github.com/mbudnek/google-home-hubitat-community/blob/master/README.md",
   "communityLink": "https://community.hubitat.com/t/alpha-community-maintained-google-home-integration/34957",


### PR DESCRIPTION
The hubVersionLessThan function would incorrectly return true if the hub version was greater than the target version but contained a piece that was less than the corresponding piece in the target version.  For example, 2.3.5.103 would be considered less than 2.3.4.115 because 103 is less than 115 even though comparison should have stopped after comparing 5 to 4.